### PR TITLE
Remove engines from the dependency requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
   ],
   "author": "Pedro Machado Santa <pedro@reedsy.com>",
   "license": "MIT",
-  "engines": {
-    "node": "~8",
-    "npm": "~5"
-  },
   "main": "dist/quill-cursors.js",
   "module": "src/cursors.js",
   "scripts": {


### PR DESCRIPTION
Using Node 9.x is perfectly fine for example. As I don't see any value of having such thing in the dependencies, I propose to remove them :)