### PR TITLE
Add a flag to suppress warnings from console

### DIFF
--- a/src/cursors.js
+++ b/src/cursors.js
@@ -109,6 +109,7 @@ QuillCursors.prototype._initOptions = function(options) {
   this.options.autoRegisterListener = (options.autoRegisterListener == false) ? options.autoRegisterListener : this.options.autoRegisterListener;
   this.options.hideDelay = (options.hideDelay == undefined) ? this.options.hideDelay : options.hideDelay;
   this.options.hideSpeed = (options.hideSpeed == undefined) ? this.options.hideSpeed : options.hideSpeed;
+  this.options.suppressWarnings = options.suppressWarnings || this.options.suppressWarnings;
 };
 
 QuillCursors.prototype._applyDelta = function(delta) {

--- a/src/cursors.js
+++ b/src/cursors.js
@@ -14,7 +14,8 @@ var DEFAULTS = {
   ].join(''),
   autoRegisterListener: true,
   hideDelay: 3000,
-  hideSpeed: 400
+  hideSpeed: 400,
+  suppressWarnings: false
 };
 
 function QuillCursors(quill, options) {
@@ -199,7 +200,7 @@ QuillCursors.prototype._updateCursor = function(cursor) {
     startLeaf[1] < 0 || endLeaf[1] < 0 ||
     !startLeaf[0].domNode || !endLeaf[0].domNode) {
 
-    console.warn('[quill-cursors] A cursor couldn\'t be updated (ID ' + cursor.userId +'), hiding.');
+    if (!this.options.suppressWarnings) console.warn('[quill-cursors] A cursor couldn\'t be updated (ID ' + cursor.userId +'), hiding.');
 
     this._hideCursor(cursor.userId);
 


### PR DESCRIPTION
We get these quill-cursor warnings when one editor is editing text at the end of a document. This adds a flag to avoid polluting the user's console.