### PR TITLE
Added typings to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "license": "MIT",
   "main": "dist/quill-cursors.js",
+  "types": "dist/quill-cursors.d.ts",
   "scripts": {
     "build": "NODE_ENV=production ./node_modules/.bin/webpack",
     "lint": "tslint --config tslint.json --project tsconfig.base.json --format stylish",
@@ -31,6 +32,7 @@
     "@types/tinycolor2": "^1.4.1",
     "clean-webpack-plugin": "^1.0.1",
     "css-loader": "^2.1.0",
+    "dts-bundle": "^0.7.3",
     "extract-text-webpack-plugin": "^3.0.2",
     "jest": "^24.1.0",
     "jest-dom": "^3.1.2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "noImplicitAny": true,
     "sourceMap": true,
     "removeComments": true,
+    "declaration": true,
   },
   "include": [
     "src/**/*",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,7 +74,7 @@ DtsBundlePlugin.prototype.apply = function (compiler) {
       main: 'src/index.d.ts',
       out: '../dist/quill-cursors.d.ts',
       removeSource: true,
-      outputAsModuleFolder: true // to use npm in-package typings
+      outputAsModuleFolder: false
     });
   });
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
-
 const environment = process.env.NODE_ENV || 'development';
 
 const moduleBundle = {
@@ -44,6 +43,7 @@ const moduleBundle = {
   },
   plugins: [
     new CleanWebpackPlugin(['dist']),
+    new DtsBundlePlugin(),
   ],
 };
 
@@ -63,5 +63,20 @@ if (environment === 'production') {
 
   delete moduleBundle.devtool;
 }
+
+function DtsBundlePlugin(){}
+DtsBundlePlugin.prototype.apply = function (compiler) {
+  compiler.plugin('done', function(){
+    const dts = require('dts-bundle');
+
+    dts.bundle({
+      name: 'QuillCursors',
+      main: 'src/index.d.ts',
+      out: '../dist/quill-cursors.d.ts',
+      removeSource: true,
+      outputAsModuleFolder: true // to use npm in-package typings
+    });
+  });
+};
 
 module.exports = [moduleBundle];


### PR DESCRIPTION
It's nice that quill-cursors switched to typescript but it would be even better if the typings were exported as well so other people using quill-cursors and typescript can make use of the types.