### PR TITLE
Fix cursor behaviour for Quill containers with fixed height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixes for editor with a fixed height container
+
 # 2.0.2
 
 - deploy.sh fix

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -49,6 +49,8 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
   display: flex;
   flex: 1;
   flex-direction: column;
+  // Make sure we don't show cursors/selection rectangles outside the editor
+  overflow: hidden;
 }
 
 .ql-editor {

--- a/example/index.html
+++ b/example/index.html
@@ -12,11 +12,15 @@
     <div class="container">
       <div class="editor">
         <h2>User 1</h2>
+        <center>(Expanding editor)</center>
+        <br>
         <div id="editor-one"></div>
       </div>
 
       <div class="editor">
         <h2>User 2</h2>
+        <center>(Fixed-height editor)</center>
+        <br>
         <div id="editor-two"></div>
       </div>
     </div>

--- a/example/styles.css
+++ b/example/styles.css
@@ -15,3 +15,7 @@ h1, h2 {
   flex-grow: 1;
   width: 40%;
 }
+
+#editor-two {
+  height: 200px;
+}

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -17,10 +17,11 @@ describe('QuillCursors', () => {
         },
       },
       addContainer: (className: string) => {
-        quill.container = document.createElement('DIV');
-        quill.container.classList.add(className);
-        document.body.appendChild(quill.container);
-        return quill.container;
+        const cursorsContainer = document.createElement('DIV');
+        cursorsContainer.classList.add(className);
+        quill.container.appendChild(cursorsContainer);
+
+        return cursorsContainer;
       },
       container: null,
       emitter: {
@@ -32,6 +33,13 @@ describe('QuillCursors', () => {
       getSelection: () => {},
       on: () => {},
     };
+
+    quill.container = document.createElement('DIV');
+    document.body.appendChild(quill.container);
+
+    const editor = document.createElement('DIV');
+    editor.classList.add('ql-editor');
+    quill.container.appendChild(editor);
   });
 
   describe('initialisation', () => {
@@ -49,6 +57,18 @@ describe('QuillCursors', () => {
       jest.spyOn(cursors, 'update');
       const resize = new Event('resize');
       window.dispatchEvent(resize);
+      expect(cursors.update).toHaveBeenCalled();
+    });
+
+    it('registers a scroll listener', () => {
+      const editor = quill.container.getElementsByClassName('ql-editor')[0];
+      jest.spyOn(editor, 'addEventListener');
+      const cursors = new QuillCursors(quill);
+      expect(editor.addEventListener).toHaveBeenCalledWith('scroll', expect.anything());
+
+      jest.spyOn(cursors, 'update');
+      const scroll = new Event('scroll');
+      editor.dispatchEvent(scroll);
       expect(cursors.update).toHaveBeenCalled();
     });
   });
@@ -179,10 +199,12 @@ describe('QuillCursors', () => {
 
     it('adds the cursor to the DOM', () => {
       const cursors = new QuillCursors(quill);
-      expect(quill.container.childElementCount).toBe(0);
+      const cursorsContainer = quill.container.getElementsByClassName(QuillCursors.CONTAINER_CLASS)[0];
+
+      expect(cursorsContainer.childElementCount).toBe(0);
 
       cursors.createCursor('abc', 'Joe Bloggs', 'red');
-      expect(quill.container.childElementCount).toBe(1);
+      expect(cursorsContainer.childElementCount).toBe(1);
     });
 
     it('can override the hide delay and speed', () => {
@@ -225,22 +247,26 @@ describe('QuillCursors', () => {
     });
 
     it('removes the cursor from the DOM', () => {
-      expect(quill.container.childElementCount).toBe(1);
+      const cursorsContainer = quill.container.getElementsByClassName(QuillCursors.CONTAINER_CLASS)[0];
+
+      expect(cursorsContainer.childElementCount).toBe(1);
       expect(cursors.cursors()).toHaveLength(1);
 
       cursors.removeCursor(cursor.id);
 
-      expect(quill.container.childElementCount).toBe(0);
+      expect(cursorsContainer.childElementCount).toBe(0);
       expect(cursors.cursors()).toHaveLength(0);
     });
 
     it('clears cursors', () => {
-      expect(quill.container.childElementCount).toBe(1);
+      const cursorsContainer = quill.container.getElementsByClassName(QuillCursors.CONTAINER_CLASS)[0];
+
+      expect(cursorsContainer.childElementCount).toBe(1);
       expect(cursors.cursors()).toHaveLength(1);
 
       cursors.clearCursors();
 
-      expect(quill.container.childElementCount).toBe(0);
+      expect(cursorsContainer.childElementCount).toBe(0);
       expect(cursors.cursors()).toHaveLength(0);
     });
 

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -21,7 +21,7 @@ export default class QuillCursors {
 
     this._registerSelectionChangeListeners();
     this._registerTextChangeListener();
-    window.addEventListener('resize', () => this.update());
+    this._registerDomListeners();
   }
 
   public createCursor(id: string, name: string, color: string): Cursor {
@@ -93,6 +93,12 @@ export default class QuillCursors {
         this.update();
       })
     );
+  }
+
+  private _registerDomListeners() {
+    window.addEventListener('resize', () => this.update());
+    const editor = this._quill.container.getElementsByClassName('ql-editor')[0];
+    editor.addEventListener('scroll', () => this.update());
   }
 
   private _updateCursor(cursor: Cursor) {


### PR DESCRIPTION
Fixes https://github.com/reedsy/quill-cursors/issues/14

If a Quill container has fixed height, then the editor scrolls.
However, there are currently two issues with the cursor behaviour when
this happens:

  - the cursors and selections will appear outside the editor
  - the selections do not update when scrolling the editor

This change addresses the above issues by:

  - setting `overflow: hidden` on `.ql-container` to hide the cursors
    when they overflow the editor
  - adding a `scroll` listener to the `.ql-editor`, which will trigger
    a cursor position update

## Before:

<img width="1277" alt="53473406-33b1b100-3a62-11e9-91bc-82f210b624bb" src="https://user-images.githubusercontent.com/12036746/53481596-78931300-3a75-11e9-9f50-ccd86b91d2e9.png">

## After

![quill cursors](https://user-images.githubusercontent.com/12036746/53481604-7cbf3080-3a75-11e9-92f2-1ca0c3b9e5e6.png)
