### PR TITLE
Add the cursor ID and a custom CSS class to the cursor container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Add custom CSS class option
+- Add HTML id attributes to the cursors
+
 # 2.0.3
 
 - Fixes for editor with a fixed height container

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm start
 The `quill-cursors` module has the following optional configuration:
 
   - `template` _string_: override the default HTML template used for a cursor
-  - `cursorCssClass` _string_: the CSS class to add to the container of each cursor
+  - `containerClass` _string_ (default: `ql-cursors`): the CSS class to add to the cursors container
   - `hideDelayMs`: _number_ (default: `3000`): number of milliseconds to show the username flag before hiding it
   - `hideSpeedMs`: _number_ (default: `400`): the duration of the flag hiding animation in milliseconds
   - `selectionChangeSource` _string_ | _null_ (default: `api`): the event source to use when emitting `selection-change`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ npm start
 The `quill-cursors` module has the following optional configuration:
 
   - `template` _string_: override the default HTML template used for a cursor
+  - `cursorCssClass` _string_: the CSS class to add to the container of each cursor
   - `hideDelayMs`: _number_ (default: `3000`): number of milliseconds to show the username flag before hiding it
   - `hideSpeedMs`: _number_ (default: `400`): the duration of the flag hiding animation in milliseconds
   - `selectionChangeSource` _string_ | _null_ (default: `api`): the event source to use when emitting `selection-change`

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -48,6 +48,20 @@ describe('Cursor', () => {
     `);
   });
 
+  it('adds a custom CSS class', () => {
+    options.cursorCssClass = 'my-class';
+    const element = new Cursor('abc', 'Jane Bloggs', 'red').build(options);
+
+    expect(element.classList).toContain('my-class');
+  });
+
+  it('adds the ID to the element', () => {
+    options.cursorCssClass = 'my-class';
+    const element = new Cursor('abc', 'Jane Bloggs', 'red').build(options);
+
+    expect(element.id).toBe('ql-cursor-abc');
+  });
+
   it('toggles element visibility', () => {
     const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
     const element = cursor.build(options);

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -48,17 +48,8 @@ describe('Cursor', () => {
     `);
   });
 
-  it('adds a custom CSS class', () => {
-    options.cursorCssClass = 'my-class';
-    const element = new Cursor('abc', 'Jane Bloggs', 'red').build(options);
-
-    expect(element.classList).toContain('my-class');
-  });
-
   it('adds the ID to the element', () => {
-    options.cursorCssClass = 'my-class';
     const element = new Cursor('abc', 'Jane Bloggs', 'red').build(options);
-
     expect(element.id).toBe('ql-cursor-abc');
   });
 

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -34,6 +34,8 @@ export default class Cursor {
   public build(options: IQuillCursorsOptions): HTMLElement {
     const element = document.createElement(Cursor.CONTAINER_ELEMENT_TAG);
     element.classList.add(Cursor.CURSOR_CLASS);
+    options.cursorCssClass && element.classList.add(options.cursorCssClass);
+    element.id = `ql-cursor-${ this.id }`;
     element.innerHTML = options.template;
     const selectionElement = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0] as HTMLElement;
     const caretContainerElement = element.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0] as HTMLElement;

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -34,7 +34,6 @@ export default class Cursor {
   public build(options: IQuillCursorsOptions): HTMLElement {
     const element = document.createElement(Cursor.CONTAINER_ELEMENT_TAG);
     element.classList.add(Cursor.CURSOR_CLASS);
-    options.cursorCssClass && element.classList.add(options.cursorCssClass);
     element.id = `ql-cursor-${ this.id }`;
     element.innerHTML = options.template;
     const selectionElement = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0] as HTMLElement;

--- a/src/quill-cursors/i-quill-cursors-options.ts
+++ b/src/quill-cursors/i-quill-cursors-options.ts
@@ -1,6 +1,6 @@
 export default interface IQuillCursorsOptions {
   template?: string;
-  cursorCssClass?: string;
+  containerClass?: string;
   selectionChangeSource?: string;
   hideDelayMs?: number;
   hideSpeedMs?: number;

--- a/src/quill-cursors/i-quill-cursors-options.ts
+++ b/src/quill-cursors/i-quill-cursors-options.ts
@@ -1,5 +1,6 @@
 export default interface IQuillCursorsOptions {
   template?: string;
+  cursorCssClass?: string;
   selectionChangeSource?: string;
   hideDelayMs?: number;
   hideSpeedMs?: number;

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -199,7 +199,7 @@ describe('QuillCursors', () => {
 
     it('adds the cursor to the DOM', () => {
       const cursors = new QuillCursors(quill);
-      const cursorsContainer = quill.container.getElementsByClassName(QuillCursors.CONTAINER_CLASS)[0];
+      const cursorsContainer = quill.container.getElementsByClassName('ql-cursors')[0];
 
       expect(cursorsContainer.childElementCount).toBe(0);
 
@@ -218,6 +218,12 @@ describe('QuillCursors', () => {
       const flag = quill.container.getElementsByClassName(Cursor.FLAG_CLASS)[0];
       expect(flag).toHaveStyle('transition-delay: 1000ms');
       expect(flag).toHaveStyle('transition-speed: 2000ms');
+    });
+
+    it('can override the Quill container class', () => {
+      new QuillCursors(quill, { containerClass: 'my-class' });
+      const containers = quill.container.getElementsByClassName('my-class');
+      expect(containers.length).toBe(1);
     });
   });
 
@@ -247,7 +253,7 @@ describe('QuillCursors', () => {
     });
 
     it('removes the cursor from the DOM', () => {
-      const cursorsContainer = quill.container.getElementsByClassName(QuillCursors.CONTAINER_CLASS)[0];
+      const cursorsContainer = quill.container.getElementsByClassName('ql-cursors')[0];
 
       expect(cursorsContainer.childElementCount).toBe(1);
       expect(cursors.cursors()).toHaveLength(1);
@@ -259,7 +265,7 @@ describe('QuillCursors', () => {
     });
 
     it('clears cursors', () => {
-      const cursorsContainer = quill.container.getElementsByClassName(QuillCursors.CONTAINER_CLASS)[0];
+      const cursorsContainer = quill.container.getElementsByClassName('ql-cursors')[0];
 
       expect(cursorsContainer.childElementCount).toBe(1);
       expect(cursors.cursors()).toHaveLength(1);

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -5,8 +5,6 @@ import * as RangeFix from 'rangefix';
 import template from './template';
 
 export default class QuillCursors {
-  public static readonly CONTAINER_CLASS = 'ql-cursors';
-
   private readonly _cursors: { [id: string]: Cursor } = {};
   private readonly _quill: any;
   private readonly _container: HTMLElement;
@@ -15,8 +13,8 @@ export default class QuillCursors {
 
   public constructor(quill: any, options: IQuillCursorsOptions = {}) {
     this._quill = quill;
-    this._container = this._quill.addContainer(QuillCursors.CONTAINER_CLASS);
     this._options = this._setDefaults(options);
+    this._container = this._quill.addContainer(this._options.containerClass);
     this._currentSelection = this._quill.getSelection();
 
     this._registerSelectionChangeListeners();
@@ -153,6 +151,7 @@ export default class QuillCursors {
     options = Object.assign({}, options);
 
     options.template = options.template || template;
+    options.containerClass = options.containerClass || 'ql-cursors';
 
     if (options.selectionChangeSource !== null) {
       options.selectionChangeSource = options.selectionChangeSource || this._quill.constructor.sources.API;


### PR DESCRIPTION
Sometimes it can be useful to adjust the CSS class attached to the
cursor container. For example, when using multiple cursor modules on the
same document.

This change adds an option to add a custom CSS class to the container.
It also adds an `id` attribute to each container, in case you want to
target a particular cursor through either CSS or JavaScript.