### PR TITLE
Use `ResizeObserver` instead of listening for window `resize` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add custom CSS class option
 - Add HTML id attributes to the cursors
+- Use ResizeObserver instead of window.onresize
 
 # 2.0.3
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "node-sass": "^4.11.0",
     "quill": "^1.3.6",
     "rangefix": "^0.2.5",
+    "resize-observer": "^1.0.0",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",
     "tinycolor2": "^1.4.1",

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -49,15 +49,23 @@ describe('QuillCursors', () => {
       expect(quill.addContainer).toHaveBeenCalledTimes(1);
     });
 
-    it('registers a window resize listener', () => {
-      jest.spyOn(window, 'addEventListener');
+    it('registers a resize observer', (done: Function) => {
       const cursors = new QuillCursors(quill);
-      expect(window.addEventListener).toHaveBeenCalledWith('resize', expect.anything());
+      const editor = quill.container.getElementsByClassName('ql-editor')[0];
+      editor.style.width = '200px';
 
       jest.spyOn(cursors, 'update');
-      const resize = new Event('resize');
-      window.dispatchEvent(resize);
-      expect(cursors.update).toHaveBeenCalled();
+
+      jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: Function) => {
+        const updateMock = <any> cursors.update;
+        if (updateMock.mock.calls.length) {
+          return done();
+        } else {
+          return callback();
+        }
+      });
+
+      editor.style.width = '100px';
     });
 
     it('registers a scroll listener', () => {

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -3,6 +3,7 @@ import Cursor from './cursor';
 import IQuillRange from './i-range';
 import * as RangeFix from 'rangefix';
 import template from './template';
+import { ResizeObserver } from 'resize-observer';
 
 export default class QuillCursors {
   private readonly _cursors: { [id: string]: Cursor } = {};
@@ -94,9 +95,10 @@ export default class QuillCursors {
   }
 
   private _registerDomListeners() {
-    window.addEventListener('resize', () => this.update());
     const editor = this._quill.container.getElementsByClassName('ql-editor')[0];
     editor.addEventListener('scroll', () => this.update());
+    const resizeObserver = new ResizeObserver(() => this.update());
+    resizeObserver.observe(editor);
   }
 
   private _updateCursor(cursor: Cursor) {


### PR DESCRIPTION
We currently listen for `resize` events fired on the window to redraw
the cursors.

However, this approach misses the event where the editor is resized for
other reasons (such as through JavaScript), without the window being
resized.

Ideally, we'd use the new [`ResizeObserver`][1] class, but this is
restricted just to Chrome for now. Instead, we're using a [polyfill][2].

[1]: https://developers.google.com/web/updates/2016/10/resizeobserver
[2]: https://github.com/pelotoncycle/resize-observer