### PR TITLE
Add local cursor transforms on `text-change`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Ignore zero-width and zero-height selection rectangles
 - Build selections from multiple `Range`s
 - Fix max Quill index bug
+- Add a local cursor transform for smoother experience on high-latency connections
 
 # 2.1.1
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ The `quill-cursors` module has the following optional configuration:
   - `hideDelayMs`: _number_ (default: `3000`): number of milliseconds to show the username flag before hiding it
   - `hideSpeedMs`: _number_ (default: `400`): the duration of the flag hiding animation in milliseconds
   - `selectionChangeSource` _string_ | _null_ (default: `api`): the event source to use when emitting `selection-change`
+  - `transformOnTextChange`: _boolean_ (default: `false`): attempt to locally infer cursor positions whenever the editor
+    contents change, without receiving an update from the other client. This can be useful for smoother performance on
+    high-latency connections.
 
 Provide these options when setting up the Quill editor:
 
@@ -82,6 +85,7 @@ const editor = new Quill('#editor', {
       hideDelayMs: 5000,
       hideSpeedMs: 0,
       selectionChangeSource: null,
+      transformOnTextChange: true,
     },
   },
 });

--- a/example/main.js
+++ b/example/main.js
@@ -1,40 +1,88 @@
 Quill.register('modules/cursors', QuillCursors);
 
+// Constant to simulate a high-latency connection when sending cursor
+// position updates.
+const CURSOR_LATENCY = 1000;
+
+// Constant to simulate a high-latency connection when sending
+// text changes.
+const TEXT_LATENCY = 500;
+
 const quillOne = new Quill('#editor-one', {
   theme: 'snow',
   modules: {
-    cursors: true,
-  }
+    cursors: {
+      transformOnTextChange: true,
+    },
+  },
 });
 
 const quillTwo = new Quill('#editor-two', {
   theme: 'snow',
   modules: {
-    cursors: true,
+    cursors: {
+      transformOnTextChange: true,
+    },
   }
 });
 
 const cursorsOne = quillOne.getModule('cursors');
 const cursorsTwo = quillTwo.getModule('cursors');
 
-cursorsOne.createCursor(2, 'User 2', 'blue');
-cursorsTwo.createCursor(1, 'User 1', 'red');
+cursorsOne.createCursor('cursor', 'User 2', 'blue');
+cursorsTwo.createCursor('cursor', 'User 1', 'red');
 
 function textChangeHandler(quill) {
   return function(delta, oldContents, source) {
     if (source === 'user') {
-      quill.updateContents(delta);
+      setTimeout(() => quill.updateContents(delta), TEXT_LATENCY);
     }
   };
+}
+
+function selectionChangeHandler(cursors) {
+  const debouncedUpdate = debounce(updateCursor, 500);
+
+  return function(range, oldRange, source) {
+    if (source === 'user') {
+      // If the user has manually updated their selection, send this change
+      // immediately, because a user update is important, and should be
+      // sent as soon as possible for a smooth experience.
+      updateCursor(range);
+    } else {
+      // Otherwise, it's a text change update or similar. These changes will
+      // automatically get transformed by the receiving client without latency.
+      // If we try to keep sending updates, then this will undo the low-latency
+      // transformation already performed, which we don't want to do. Instead,
+      // add a debounce so that we only send the update once the user has stopped
+      // typing, which ensures we send the most up-to-date position (which should
+      // hopefully match what the receiving client already thinks is the cursor
+      // position anyway).
+      debouncedUpdate(range);
+    }
+  };
+
+  function updateCursor(range) {
+    // Use a timeout to simulate a high latency connection.
+    setTimeout(() => cursors.moveCursor('cursor', range), CURSOR_LATENCY);
+  }
 }
 
 quillOne.on('text-change', textChangeHandler(quillTwo));
 quillTwo.on('text-change', textChangeHandler(quillOne));
 
-quillOne.on('selection-change', function(range) {
-  cursorsTwo.moveCursor(1, range);
-});
+quillOne.on('selection-change', selectionChangeHandler(cursorsTwo));
+quillTwo.on('selection-change', selectionChangeHandler(cursorsOne));
 
-quillTwo.on('selection-change', function(range) {
-  cursorsOne.moveCursor(2, range);
-});
+function debounce(func, wait) {
+  var timeout;
+  return function(...args) {
+    var context = this;
+    var later = function() {
+      timeout = null;
+      func.apply(context, args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jest-dom": "^3.1.2",
     "node-sass": "^4.11.0",
     "quill": "^1.3.6",
+    "quill-delta": "^4.2.1",
     "rangefix": "^0.2.7",
     "resize-observer": "^1.0.0",
     "sass-loader": "^7.1.0",

--- a/src/quill-cursors/i-quill-cursors-options.ts
+++ b/src/quill-cursors/i-quill-cursors-options.ts
@@ -4,4 +4,5 @@ export default interface IQuillCursorsOptions {
   selectionChangeSource?: string;
   hideDelayMs?: number;
   hideSpeedMs?: number;
+  transformOnTextChange?: boolean;
 }

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -102,9 +102,14 @@ describe('QuillCursors', () => {
       expect(listeners['text-change']).toBeTruthy();
     });
 
-    it('does not register the text change listener if setting the source to null', () => {
+    it('does not emit a selection change event if setting the source to null', () => {
+      jest.useFakeTimers();
       new QuillCursors(quill, { selectionChangeSource: null });
-      expect(listeners['text-change']).toBeFalsy();
+
+      listeners['text-change']();
+      jest.runAllTimers();
+
+      expect(quill.emitter.emit).not.toHaveBeenCalled();
     });
 
     it('emits the selection on text change', () => {
@@ -139,6 +144,22 @@ describe('QuillCursors', () => {
         { index: 0, length: 0 },
         'quill-cursors'
       );
+    });
+
+    it('transforms an existing cursor after an insertion', () => {
+      jest.useFakeTimers();
+      const cursors = new QuillCursors(quill, { transformOnTextChange: true });
+      const cursor = cursors.createCursor('abc', 'Joe Bloggs', 'red');
+      cursors.moveCursor('abc', { index: 10, length: 5 });
+
+      const delta = [
+        { retain: 5 },
+        { insert: 'foo' },
+      ];
+      listeners['text-change'](delta);
+      jest.runAllTimers();
+
+      expect(cursor.range).toEqual({ index: 13, length: 5 });
     });
   });
 

--- a/typings/quill-delta.d.ts
+++ b/typings/quill-delta.d.ts
@@ -1,0 +1,1 @@
+declare module 'quill-delta';


### PR DESCRIPTION
Fixes https://github.com/reedsy/quill-cursors/issues/25

At the moment, we have to wait for clients to report their position
before we update it. This is fine on very low-latency connections (like
when developing on the same machine), but on high-latency connections,
it can lead to some laggy or juddery performance as the cursor drifts
out-of-sync with the `text-change` events received by Quill:

![Mar-29-2019 08-44-15](https://user-images.githubusercontent.com/12036746/55227311-6d1f3d00-5217-11e9-8e7b-d7a1398feadf.gif)

This change adds in a `text-change` listener that will transform all
cursors by the received delta using `quill-delta`'s `transformPosition`,
which is meant for exactly this sort of application.

The example has also been updated to show how a cursor implementation
might look on a high-latency connection, using a debounced update to
avoid laggy behaviour.
