### PR TITLE
Add selection `span` elements in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Sort selection `span` elements
+
 # 2.1.0
 
 - Add custom CSS class option

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jest-dom": "^3.1.2",
     "node-sass": "^4.11.0",
     "quill": "^1.3.6",
-    "rangefix": "^0.2.5",
+    "rangefix": "^0.2.7",
     "resize-observer": "^1.0.0",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -105,19 +105,21 @@ describe('Cursor', () => {
     let cursor: Cursor;
     let element: HTMLElement;
     let container: any;
+    let selection1: any;
+    let selection2: any;
 
     beforeEach(() => {
       cursor = new Cursor('abc', 'Jane Bloggs', 'red');
       element = cursor.build(options);
 
-      const selection1: any = {
+      selection1 = {
         top: 0,
         left: 50,
         width: 100,
         height: 200,
       };
 
-      const selection2: any = {
+      selection2 = {
         top: 1000,
         left: 1050,
         width: 200,
@@ -156,6 +158,37 @@ describe('Cursor', () => {
       cursor.updateSelection(null, container);
       const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
       expect(selections.children).toHaveLength(0);
+    });
+
+    it('sorts the selections by DOM position', () => {
+      cursor.updateSelection([selection2, selection1], container);
+
+      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
+
+      expect(selections.children[0]).toHaveStyle('top: 0px');
+      expect(selections.children[0]).toHaveStyle('left: 50px');
+
+      expect(selections.children[1]).toHaveStyle('top: 1000px');
+      expect(selections.children[1]).toHaveStyle('left: 1050px');
+    });
+
+    it('sorts by left-to-right if the selection tops are the same', () => {
+      const selection3 = {
+        top: 0,
+        left: 150,
+        width: 100,
+        height: 200,
+      };
+
+      cursor.updateSelection([selection3, selection1], container);
+
+      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
+
+      expect(selections.children[0]).toHaveStyle('top: 0px');
+      expect(selections.children[0]).toHaveStyle('left: 50px');
+
+      expect(selections.children[1]).toHaveStyle('top: 0px');
+      expect(selections.children[1]).toHaveStyle('left: 150px');
     });
   });
 });

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -80,10 +80,8 @@ export default class Cursor {
 
   public updateSelection(selections: ClientRect[], container: ClientRect) {
     this._clearSelection();
-    selections = selections || [];
-
-    Array.from(selections)
-      .forEach((selection: ClientRect) => this._addSelection(selection, container));
+    selections = this._sortByDomPosition(selections);
+    selections.forEach((selection: ClientRect) => this._addSelection(selection, container));
   }
 
   private _clearSelection() {
@@ -106,5 +104,19 @@ export default class Cursor {
     element.style.backgroundColor = tinycolor(this.color).setAlpha(0.3).toString();
 
     return element;
+  }
+
+  private _sortByDomPosition(selections: ClientRect[]): ClientRect[] {
+    if (!selections) {
+      return [];
+    }
+
+    return Array.from(selections).sort((a, b) => {
+      if (a.top === b.top) {
+        return a.left - b.left;
+      }
+
+      return a.top - b.top;
+    });
   }
 }

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -312,6 +312,7 @@ describe('QuillCursors', () => {
             const rectangles: any[] = [];
             return rectangles;
           },
+          getBoundingClientRect: () => ({}),
           cloneRange: () => range,
         };
 
@@ -350,7 +351,7 @@ describe('QuillCursors', () => {
       expect(cursor.show).not.toHaveBeenCalled();
     });
 
-    it('shows a cursors with a valid range and leaf', () => {
+    it('shows a cursor with a valid range and leaf', () => {
       jest.spyOn(cursor, 'hide');
       jest.spyOn(cursor, 'show');
       jest.spyOn(quill, 'getLeaf').mockReturnValue([


### PR DESCRIPTION
Fixes https://github.com/reedsy/quill-cursors/issues/29

At the moment, the `span` elements that make up a multi-line selection
are not necessarily added in the correct "order" (ie from top-left to
bottom-right of the document). Sometimes we may want these in order so
that we can style them using CSS selectors like `:first-child`.

This works by accident currently in Chrome, but not in Firefox. This
change actively sorts the `span` elements by their rectangles from
top-to-bottom, and then left-to-right. Note that we ignore right-to-left
text as out-of-scope for this change.