### PR TITLE
Deduplicate perfectly overlapping client rectangles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Sort selection `span` elements
+- Deduplicate perfectly overlapping selection rectangles
 
 # 2.1.0
 

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -190,5 +190,16 @@ describe('Cursor', () => {
       expect(selections.children[1]).toHaveStyle('top: 0px');
       expect(selections.children[1]).toHaveStyle('left: 150px');
     });
+
+    it('deduplicates selections', () => {
+      cursor.updateSelection([selection1, selection1], container);
+
+      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
+
+      expect(selections.children).toHaveLength(1);
+
+      expect(selections.children[0]).toHaveStyle('top: 0px');
+      expect(selections.children[0]).toHaveStyle('left: 50px');
+    });
   });
 });

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -80,6 +80,9 @@ export default class Cursor {
 
   public updateSelection(selections: ClientRect[], container: ClientRect) {
     this._clearSelection();
+    selections = selections || [];
+    selections = Array.from(selections);
+    selections = this._deduplicate(selections);
     selections = this._sortByDomPosition(selections);
     selections.forEach((selection: ClientRect) => this._addSelection(selection, container));
   }
@@ -107,16 +110,35 @@ export default class Cursor {
   }
 
   private _sortByDomPosition(selections: ClientRect[]): ClientRect[] {
-    if (!selections) {
-      return [];
-    }
-
-    return Array.from(selections).sort((a, b) => {
+    return selections.sort((a, b) => {
       if (a.top === b.top) {
         return a.left - b.left;
       }
 
       return a.top - b.top;
     });
+  }
+
+  private _deduplicate(selections: ClientRect[]): ClientRect[] {
+    const serializedSelections = new Set();
+
+    return selections.filter((selection: ClientRect) => {
+      const serialized = this._serialize(selection);
+      if (serializedSelections.has(serialized)) {
+        return false;
+      }
+
+      serializedSelections.add(serialized);
+      return true;
+    });
+  }
+
+  private _serialize(selection: ClientRect): string {
+    return [
+      `top:${ selection.top }`,
+      `right:${ selection.right }`,
+      `bottom:${ selection.bottom }`,
+      `left:${ selection.left }`,
+    ].join(';');
   }
 }


### PR DESCRIPTION
If the user's selection contains some formatted text, the selection can
contain overlapping rectangles, which leads to a selection with varying
opacity.

This change checks for these identical rectangles and deduplicates them.