### PR TITLE
Ignore zero-height and zero-width selection rectangles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Move selection behind text with `z-index` so that other users' selections don't block interaction with the editor
+- Ignore zero-width and zero-height selection rectangles
 
 # 2.1.1
 

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -201,5 +201,41 @@ describe('Cursor', () => {
       expect(selections.children[0]).toHaveStyle('top: 0px');
       expect(selections.children[0]).toHaveStyle('left: 50px');
     });
+
+    it('ignores selections with no width', () => {
+      const noWidthSelection = {
+        top: 0,
+        left: 0,
+        width: 0,
+        height: 100,
+      };
+
+      cursor.updateSelection([selection1, noWidthSelection], container);
+
+      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
+
+      expect(selections.children).toHaveLength(1);
+
+      expect(selections.children[0]).toHaveStyle('top: 0px');
+      expect(selections.children[0]).toHaveStyle('left: 50px');
+    });
+
+    it('ignores selections with no height', () => {
+      const noHeightSelection = {
+        top: 0,
+        left: 0,
+        width: 100,
+        height: 0,
+      };
+
+      cursor.updateSelection([selection1, noHeightSelection], container);
+
+      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
+
+      expect(selections.children).toHaveLength(1);
+
+      expect(selections.children[0]).toHaveStyle('top: 0px');
+      expect(selections.children[0]).toHaveStyle('left: 50px');
+    });
   });
 });

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -82,7 +82,7 @@ export default class Cursor {
     this._clearSelection();
     selections = selections || [];
     selections = Array.from(selections);
-    selections = this._deduplicate(selections);
+    selections = this._sanitize(selections);
     selections = this._sortByDomPosition(selections);
     selections.forEach((selection: ClientRect) => this._addSelection(selection, container));
   }
@@ -119,10 +119,14 @@ export default class Cursor {
     });
   }
 
-  private _deduplicate(selections: ClientRect[]): ClientRect[] {
+  private _sanitize(selections: ClientRect[]): ClientRect[] {
     const serializedSelections = new Set();
 
     return selections.filter((selection: ClientRect) => {
+      if (!selection.width || !selection.height) {
+        return false;
+      }
+
       const serialized = this._serialize(selection);
       if (serializedSelections.has(serialized)) {
         return false;


### PR DESCRIPTION
Sometimes selection rectangles can come back with zero height or zero
width. In these cases, we should just ignore the rectangle.