### PR TITLE
Move selection behind text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Move selection behind text with `z-index` so that other users' selections don't block interaction with the editor
+
 # 2.1.1
 
 - Sort selection `span` elements

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -131,5 +131,6 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
 
   .ql-cursor-selection-block {
     position: absolute;
+    z-index: -1;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/reedsy/quill-cursors/issues/32

At the moment, when we add a selection using `span` elements, they
appear further down the DOM, and hence are put "on top" of the editor
text. In other words, if another user has highlighted some text, then
their selection will prevent me from placing my cursor inside it.

This change moves the selection behind the text with a `z-index: -1`,
which avoids intercepting the click on the editor. It should be noted
that this will also hide the selections if a background is applied to
the editor, but fixing that case is left to the consumer.