### PR TITLE
Use pointer-events: none for selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Move selection behind text with `z-index` so that other users' selections don't block interaction with the editor
+- Apply `pointer-events: none` CSS to selections so that other users' selections don't block mouse and touch interaction
 - Ignore zero-width and zero-height selection rectangles
 
 # 2.1.1

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -131,6 +131,6 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
 
   .ql-cursor-selection-block {
     position: absolute;
-    z-index: -1;
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
We previously set the selections' `z-index: -1` to avoid the selections
blocking click events. However, this doesn't work on block-level
elements, such as `image-block`s, because the selection is perfectly
behind the image.

This change removes the `z-index` assignment, and we instead let the
selections remain on top, but we apply `pointer-events: none` to avoid
the selections reacting to `click` or `touch` events.