### PR TITLE
Build selection from multiple Ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Apply `pointer-events: none` CSS to selections so that other users' selections don't block mouse and touch interaction
 - Ignore zero-width and zero-height selection rectangles
+- Build selections from multiple `Range`s
 
 # 2.1.1
 


### PR DESCRIPTION
Fixes https://github.com/reedsy/quill-cursors/issues/35

We currently build a selection from a single `Range` object, which can
contain a mixture of `inline` and `block` elements. In particular, with
paragraphs, the behaviour between browsers is inconsistent.

For example, when selecting an entire paragraph, Chrome will draw
rectangles around each line in the paragraph, as well as a big rectangle
around the `<p>` element itself. Firefox, on the other hand, will only
draw a rectangle around the `<p>` block, but not the individual lines.
Both of these behaviours are different still to how the browser's
built-in "selection" looks (ie just drawing rectangles around the
individual lines, and never the `<p>` element).

In order to simulate this more "natural" selection behaviour, this
change leans a bit more on Quill, and requests all of the Quill `Block`s
in a given range. For each of these `Block`s, we create a DOM `Range`
object, which avoids ever selecting the parent `Block` (unless that
`Block` is an embed like an `image-block`, in which case it will be
selected).

## Before

### Chrome

<img width="503" alt="Screenshot 2019-07-01 at 16 05 50" src="https://user-images.githubusercontent.com/12036746/60447004-6dfeab00-9c1a-11e9-873a-6fc51e6fa05c.png">

### Firefox

<img width="522" alt="Screenshot 2019-07-01 at 16 09 38" src="https://user-images.githubusercontent.com/12036746/60447129-ac946580-9c1a-11e9-947e-ce213931e7e4.png">


## After

<img width="517" alt="Screenshot 2019-07-01 at 16 06 16" src="https://user-images.githubusercontent.com/12036746/60446910-3e4fa300-9c1a-11e9-9c0b-a80b7569901e.png">


