### PR TITLE
Adding functions to flash a cursor

### DIFF
--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -88,6 +88,13 @@ export default class Cursor {
     selections.forEach((selection: ClientRect) => this._addSelection(selection, container));
   }
 
+  public flash() {
+    this._flagEl.style.transition = 'visibility 0s 0s, opacity 0.3s linear';
+    this._flagEl.style.opacity = '1';
+    this._flagEl.style.visibility = 'visible';
+    this._delayedFade();
+  }
+
   private _clearSelection() {
     this._selectionEl.innerHTML = null;
   }
@@ -158,12 +165,5 @@ export default class Cursor {
       clearTimeout(this._timer);
     }
     this._timer = window.setTimeout(() => this._fade(this._flagEl), 2000);
-  }
-
-  public flash() {
-    this._flagEl.style.transition = 'visibility 0s 0s, opacity 0.3s linear';
-    this._flagEl.style.opacity = '1';
-    this._flagEl.style.visibility = 'visible';
-    this._delayedFade();
   }
 }

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -24,6 +24,7 @@ export default class Cursor {
   private _selectionEl: HTMLElement;
   private _caretEl: HTMLElement;
   private _flagEl: HTMLElement;
+  private _timer: number;
 
   public constructor(id: string, name: string, color: string) {
     this.id = id;
@@ -144,5 +145,25 @@ export default class Cursor {
       `bottom:${ selection.bottom }`,
       `left:${ selection.left }`,
     ].join(';');
+  }
+
+  private _fade(flagEl: HTMLElement) {
+    this._flagEl.style.transition = 'visibility 0s 1s, opacity 1s linear';
+    flagEl.style.opacity = '0';
+    flagEl.style.visibility = 'hidden';
+  }
+
+  private _delayedFade() {
+    if (this._timer) {
+      clearTimeout(this._timer);
+    }
+    this._timer = window.setTimeout(() => this._fade(this._flagEl), 2000);
+  }
+
+  public flash() {
+    this._flagEl.style.transition = 'visibility 0s 0s, opacity 0.3s linear';
+    this._flagEl.style.opacity = '1';
+    this._flagEl.style.visibility = 'visible';
+    this._delayedFade();
   }
 }

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -194,4 +194,11 @@ export default class QuillCursors {
       return ranges.concat(range);
     }, []);
   }
+
+ public flashCursor(id: string) {
+    const cursor = this._cursors[id];
+    if (cursor) {
+      cursor.flash();
+    }
+  }
 }

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -69,6 +69,13 @@ export default class QuillCursors {
       .map(key => this._cursors[key]);
   }
 
+  public flashCursor(id: string) {
+    const cursor = this._cursors[id];
+    if (cursor) {
+      cursor.flash();
+    }
+  }
+
   private _registerSelectionChangeListeners() {
     this._quill.on(
       this._quill.constructor.events.SELECTION_CHANGE,
@@ -193,12 +200,5 @@ export default class QuillCursors {
 
       return ranges.concat(range);
     }, []);
-  }
-
-  public flashCursor(id: string) {
-    const cursor = this._cursors[id];
-    if (cursor) {
-      cursor.flash();
-    }
   }
 }

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -195,7 +195,7 @@ export default class QuillCursors {
     }, []);
   }
 
- public flashCursor(id: string) {
+  public flashCursor(id: string) {
     const cursor = this._cursors[id];
     if (cursor) {
       cursor.flash();


### PR DESCRIPTION
In our implementation, we would like the username to be shown whenever the user is actively editing. We solved this by adding a flashCursor function, which restarts a timer. If the flashCursor function is continually called, the flag will continue to be shown, but if it times out (2000 ms), it will fade away. 

We have used this code in practice for a while, and it works great. Getting a version of this merged would be nice, because it would allow us to stop using a fork. It's possible that the way I implemented it (setting the CSS from the function) is not the cleanest, I'm happy for suggestions on how to rewrite it. 

Since we are using @teamworks ot-json0 and @minervaproject/rich-text which enables us to transform the cursor, we do not send presence updates other than when the user manually moves their cursor. So to identify which cursor to flash when the cursors move due to operations applied, we add a u: parameter with the userid to the editing ops, and flash cursors based on the presence of this parameter.