### PR TITLE
Fix max Quill index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Apply `pointer-events: none` CSS to selections so that other users' selections don't block mouse and touch interaction
 - Ignore zero-width and zero-height selection rectangles
 - Build selections from multiple `Range`s
+- Fix max Quill index bug
 
 # 2.1.1
 

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -368,7 +368,7 @@ describe('QuillCursors', () => {
       cursors.moveCursor(cursor.id, { index: -10, length: 100 });
 
       expect(quill.getLeaf).toHaveBeenCalledWith(0);
-      expect(quill.getLeaf).toHaveBeenCalledWith(10);
+      expect(quill.getLeaf).toHaveBeenCalledWith(9);
     });
 
     it('selects a block embed element', () => {
@@ -384,7 +384,7 @@ describe('QuillCursors', () => {
       expect(mockRange.selectNode).toHaveBeenCalledWith(img);
     });
 
-    it('sets the range for a single line on the start and leafs', () => {
+    it('sets the range for a single line on the start and end leafs', () => {
       const startIndex = 0;
       const endIndex = 2;
       const startLeaf = createLeaf();

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -130,8 +130,10 @@ export default class QuillCursors {
   }
 
   private _indexWithinQuillBounds(index: number): number {
+    const quillLength = this._quill.getLength();
+    const maxQuillIndex = quillLength ? quillLength - 1 : 0;
     index = Math.max(index, 0);
-    index = Math.min(index, this._quill.getLength());
+    index = Math.min(index, maxQuillIndex);
     return index;
   }
 


### PR DESCRIPTION
When we try to highlight a range, we first attempt to normalise it to
within Quill's bounds. However, the upper limit we apply is the length
of the Quill document, when actually - because Quill is zero-indexed -
we should set the upper limit to `quill.getLength() - 1`.

This change updates our upper limit so that we avoid getting errors when
attempting to set the selection outside the allowable range.