### PR TITLE
Fix `null` being rendered on clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Fix 'null' being rendered in IE
+
 # 2.2.1
 
 - Fix bad npm publish

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -88,7 +88,7 @@ export default class Cursor {
   }
 
   private _clearSelection() {
-    this._selectionEl.innerHTML = null;
+    this._selectionEl.innerHTML = '';
   }
 
   private _addSelection(selection: ClientRect, container: ClientRect) {


### PR DESCRIPTION
Fixes https://github.com/reedsy/quill-cursors/issues/45

When setting an element's `innerHTML` to `null`, Internet Explorer will
render this as a ["null" text node][1]. This change instead replaces the
contents with an empty string, which should be rendered correctly
across all browsers.

[1]: https://github.com/reedsy/quill-cursors/issues/45