### PR TITLE
Allow manually showing and hiding flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Feature: manually toggle cursor flag
+
 # 2.2.2
 
 - Fix 'null' being rendered in IE

--- a/README.md
+++ b/README.md
@@ -181,6 +181,17 @@ clearCursors(): void;
 
 Removes all the cursors from the DOM.
 
+#### `toggleFlag`
+
+```typescript
+toggleFlag(id: string, shouldShow?: boolean): void;
+```
+
+Toggles display of the flag for the cursor with the given `id`.
+
+- `id` _string_: the ID of the cursor whose flag should be toggled
+- `shouldShow` _boolean_ (optional): if set to `true`, will display the flag. If set to `false`, will hide it. If omitted, the flag's display state will be toggled.
+
 #### `cursors`
 
 ```typescript

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -107,6 +107,7 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
   }
 
   .ql-cursor-flag:hover,
+  .ql-cursor-flag.show-flag,
   .ql-cursor-caret-container:hover + .ql-cursor-flag {
     opacity: 1;
     visibility: visible;

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -101,6 +101,20 @@ describe('Cursor', () => {
     expect(flag).toHaveStyle('left: 200px');
   });
 
+  it('toggles the flag display', () => {
+    const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+    const element = cursor.build(options);
+    const flag = element.getElementsByClassName(Cursor.FLAG_CLASS)[0];
+
+    expect(flag).not.toHaveClass(Cursor.SHOW_FLAG_CLASS);
+    cursor.toggleFlag(true);
+    expect(flag).toHaveClass(Cursor.SHOW_FLAG_CLASS);
+    cursor.toggleFlag(false);
+    expect(flag).not.toHaveClass(Cursor.SHOW_FLAG_CLASS);
+    cursor.toggleFlag();
+    expect(flag).toHaveClass(Cursor.SHOW_FLAG_CLASS);
+  });
+
   describe('with some selections', () => {
     let cursor: Cursor;
     let element: HTMLElement;

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -11,6 +11,7 @@ export default class Cursor {
   public static readonly CARET_CLASS = 'ql-cursor-caret';
   public static readonly CARET_CONTAINER_CLASS = 'ql-cursor-caret-container';
   public static readonly FLAG_CLASS = 'ql-cursor-flag';
+  public static readonly SHOW_FLAG_CLASS = 'show-flag';
   public static readonly FLAG_FLAP_CLASS = 'ql-cursor-flag-flap';
   public static readonly NAME_CLASS = 'ql-cursor-name';
   public static readonly HIDDEN_CLASS = 'hidden';
@@ -67,6 +68,10 @@ export default class Cursor {
 
   public remove(): void {
     this._el.parentNode.removeChild(this._el);
+  }
+
+  public toggleFlag(shouldShow?: boolean): void {
+    this._flagEl.classList.toggle(Cursor.SHOW_FLAG_CLASS, shouldShow);
   }
 
   public updateCaret(rectangle: ClientRect): void {

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -484,6 +484,23 @@ describe('QuillCursors', () => {
     });
   });
 
+  describe('flag', () => {
+    it('toggles the flag of a cursor', () => {
+      const cursors = new QuillCursors(quill);
+      cursors.createCursor('abc', 'Joe Bloggs', 'red');
+
+      const flag = quill.container.getElementsByClassName(Cursor.FLAG_CLASS)[0];
+      expect(flag).not.toHaveClass(Cursor.SHOW_FLAG_CLASS);
+      cursors.toggleFlag('abc', true);
+      expect(flag).toHaveClass(Cursor.SHOW_FLAG_CLASS);
+    });
+
+    it('does not throw if the cursor does not exist', () => {
+      const cursors = new QuillCursors(quill);
+      expect(() => cursors.toggleFlag('abc')).not.toThrow();
+    });
+  });
+
   function createLeaf(): any[] {
     return [
       {domNode: document.createElement('DIV')},

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -65,6 +65,15 @@ export default class QuillCursors {
     this.cursors().forEach((cursor: Cursor) => this.removeCursor(cursor.id));
   }
 
+  public toggleFlag(id: string, shouldShow?: boolean): void {
+    const cursor = this._cursors[id];
+    if (!cursor) {
+      return;
+    }
+
+    cursor.toggleFlag(shouldShow);
+  }
+
   public cursors(): Cursor[] {
     return Object.keys(this._cursors)
       .map((key) => this._cursors[key]);


### PR DESCRIPTION
This change adds a feature to address a couple of pull requests that
have come up wanting the ability to control flag display:

  - https://github.com/reedsy/quill-cursors/pull/41
  - https://github.com/reedsy/quill-cursors/pull/48

Both of the above cases want slightly different behaviour, so this
change does the minimum work to satisfy both (ie allow control of
whether a cursor's flag is displayed), whilst also keeping our API
surface small.