### PR TITLE
Hide flag immediately when actively toggling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Hide flag immediately when actively toggled
+
 # 2.3.0
 
 - Feature: manually toggle cursor flag

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -114,6 +114,10 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
     transition: none;
   }
 
+  .ql-cursor-flag.no-delay[style] {
+    transition-delay: unset !important;
+  }
+
   .ql-cursor-caret-container {
     margin-left: -$spacing-sm;
     padding: 0 $spacing-sm;

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -23,6 +23,8 @@ describe('Cursor', () => {
       hideDelayMs: 100,
       hideSpeedMs: 200,
     };
+
+    jest.useFakeTimers();
   });
 
   it('stores constructor parameters', () => {
@@ -113,6 +115,18 @@ describe('Cursor', () => {
     expect(flag).not.toHaveClass(Cursor.SHOW_FLAG_CLASS);
     cursor.toggleFlag();
     expect(flag).toHaveClass(Cursor.SHOW_FLAG_CLASS);
+  });
+
+  it('removes the delay when actively hiding the flag', () => {
+    const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+    const element = cursor.build(options);
+    const flag = element.getElementsByClassName(Cursor.FLAG_CLASS)[0];
+
+    cursor.toggleFlag(true);
+    cursor.toggleFlag(false);
+    expect(flag).toHaveClass(Cursor.NO_DELAY_CLASS);
+    jest.advanceTimersByTime(options.hideSpeedMs);
+    expect(flag).not.toHaveClass(Cursor.NO_DELAY_CLASS);
   });
 
   describe('with some selections', () => {

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -15,6 +15,7 @@ export default class Cursor {
   public static readonly FLAG_FLAP_CLASS = 'ql-cursor-flag-flap';
   public static readonly NAME_CLASS = 'ql-cursor-name';
   public static readonly HIDDEN_CLASS = 'hidden';
+  public static readonly NO_DELAY_CLASS = 'no-delay';
 
   public readonly id: string;
   public readonly name: string;
@@ -25,6 +26,8 @@ export default class Cursor {
   private _selectionEl: HTMLElement;
   private _caretEl: HTMLElement;
   private _flagEl: HTMLElement;
+  private _hideDelay: string;
+  private _hideSpeedMs: number;
 
   public constructor(id: string, name: string, color: string) {
     this.id = id;
@@ -47,8 +50,10 @@ export default class Cursor {
 
     element.getElementsByClassName(Cursor.NAME_CLASS)[0].textContent = this.name;
 
-    flagElement.style.transitionDelay = `${options.hideDelayMs}ms`;
-    flagElement.style.transitionDuration = `${options.hideSpeedMs}ms`;
+    this._hideDelay = `${options.hideDelayMs}ms`;
+    this._hideSpeedMs = options.hideSpeedMs;
+    flagElement.style.transitionDelay = this._hideDelay;
+    flagElement.style.transitionDuration = `${this._hideSpeedMs}ms`;
 
     this._el = element;
     this._selectionEl = selectionElement;
@@ -71,7 +76,11 @@ export default class Cursor {
   }
 
   public toggleFlag(shouldShow?: boolean): void {
-    this._flagEl.classList.toggle(Cursor.SHOW_FLAG_CLASS, shouldShow);
+    const isShown = this._flagEl.classList.toggle(Cursor.SHOW_FLAG_CLASS, shouldShow);
+    if (isShown) return;
+    this._flagEl.classList.add(Cursor.NO_DELAY_CLASS);
+    // We have to wait for the animation before we can put the delay back
+    setTimeout(() => this._flagEl.classList.remove(Cursor.NO_DELAY_CLASS), this._hideSpeedMs);
   }
 
   public updateCaret(rectangle: ClientRect): void {


### PR DESCRIPTION
This change updates our new flag toggling logic so that if a flag is
actively toggled, it is hidden immediately (ignoring the configured
`hideDelayMs` option). The hide delay should still apply in the hover
case.

We achieve this by adding a `.no-delay` class to the flag when we toggle
it, which suppresses the `transition-delay`. We have then wait for the
animation to complete before removing it again, so that the flag still
behaves as configured on hover.