### PR TITLE
Always try to fit cursor flag into container

### DIFF
--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -91,6 +91,7 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
       margin-right: $spacing-xs / 2;
       display: inline-block;
       margin-top: -2px;
+      white-space: nowrap;
     }
 
     .ql-cursor-flag-flap {

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -70,6 +70,12 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
     visibility: hidden;
     color: white;
     padding-bottom: 2px;
+    border-radius: 0 $border-width-lg $border-width-lg 0;
+
+    &.flag-flipped {
+      border-radius: $border-width-lg 0 0 $border-width-lg;
+      transform: translate3d(calc(-100% + #{$border-width-base / 2} ), -100%, 0);
+    }
 
     @include transition((
       opacity,
@@ -82,18 +88,6 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
       display: inline-block;
       margin-top: -2px;
       white-space: nowrap;
-    }
-
-    .ql-cursor-flag-flap {
-      display: inline-block;
-      z-index: -1;
-      width: $spacing-xs;
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      right: -$spacing-xs / 2;
-      border-radius: $border-width-lg;
-      background-color: inherit;
     }
   }
 

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -84,7 +84,7 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
 
     .ql-cursor-name {
       margin-left: $spacing-xs;
-      margin-right: $spacing-xs / 2;
+      margin-right: $spacing-xs;
       display: inline-block;
       margin-top: -2px;
       white-space: nowrap;

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -91,7 +91,14 @@ describe('Cursor', () => {
       height: 50,
     };
 
-    cursor.updateCaret(rectangle);
+    const boundRectangle: any = {
+      top: 0,
+      left: 0,
+      height: 50000,
+      width: 50000,
+    };
+
+    cursor.updateCaret(rectangle, boundRectangle);
 
     const caretContainer = element.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0];
     expect(caretContainer).toHaveStyle('top: 100px');
@@ -101,6 +108,35 @@ describe('Cursor', () => {
     const flag = element.getElementsByClassName(Cursor.FLAG_CLASS)[0];
     expect(flag).toHaveStyle('top: 100px');
     expect(flag).toHaveStyle('left: 200px');
+  });
+
+  it('updates the caret position fitting flag', () => {
+    const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+    const element = cursor.build(options);
+
+    const rectangle: any = {
+      top: 100,
+      left: 700,
+      height: 50,
+    };
+
+    const boundRectangle: any = {
+      top: 0,
+      left: 0,
+      height: 50000,
+      width: 550,
+    };
+
+    cursor.updateCaret(rectangle, boundRectangle);
+
+    const caretContainer = element.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0];
+    expect(caretContainer).toHaveStyle('top: 100px');
+    expect(caretContainer).toHaveStyle('left: 700px');
+    expect(caretContainer).toHaveStyle('height: 50px');
+
+    const flag = element.getElementsByClassName(Cursor.FLAG_CLASS)[0];
+    expect(flag).toHaveStyle('top: 100px');
+    expect(flag).toHaveStyle('left: 550px');
   });
 
   it('toggles the flag display', () => {

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -22,6 +22,7 @@ describe('Cursor', () => {
       template: template,
       hideDelayMs: 100,
       hideSpeedMs: 200,
+      positionFlag: null,
     };
 
     jest.useFakeTimers();
@@ -110,7 +111,7 @@ describe('Cursor', () => {
     expect(flag).toHaveStyle('left: 200px');
   });
 
-  it('updates the caret position fitting flag', () => {
+  it('updates the caret position flipping flag', () => {
     const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
     const element = cursor.build(options);
 
@@ -136,7 +137,31 @@ describe('Cursor', () => {
 
     const flag = element.getElementsByClassName(Cursor.FLAG_CLASS)[0];
     expect(flag).toHaveStyle('top: 100px');
-    expect(flag).toHaveStyle('left: 550px');
+    expect(flag).toHaveStyle('left: 700px');
+    expect(flag).toHaveClass(Cursor.FLAG_FLIPPED_CLASS);
+  });
+
+  it('updates flag with custom position method', () => {
+    const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+    options.positionFlag = jest.fn();
+    cursor.build(options);
+
+    const rectangle: any = {
+      top: 100,
+      left: 200,
+      height: 50,
+    };
+
+    const boundRectangle: any = {
+      top: 0,
+      left: 0,
+      height: 50000,
+      width: 50000,
+    };
+
+    cursor.updateCaret(rectangle, boundRectangle);
+
+    expect(options.positionFlag).toHaveBeenCalled();
   });
 
   it('toggles the flag display', () => {

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -83,13 +83,16 @@ export default class Cursor {
     setTimeout(() => this._flagEl.classList.remove(Cursor.NO_DELAY_CLASS), this._hideSpeedMs);
   }
 
-  public updateCaret(rectangle: ClientRect): void {
+  public updateCaret(rectangle: ClientRect, container: ClientRect): void {
+    const flagRect = this._flagEl.getBoundingClientRect();
+
     this._caretEl.style.top = `${rectangle.top}px`;
     this._caretEl.style.left = `${rectangle.left}px`;
     this._caretEl.style.height = `${rectangle.height}px`;
 
+    const flagLeft = Math.min(container.width - flagRect.width, rectangle.left);
+    this._flagEl.style.left = `${flagLeft}px`;
     this._flagEl.style.top = `${rectangle.top}px`;
-    this._flagEl.style.left = `${rectangle.left}px`;
   }
 
   public updateSelection(selections: ClientRect[], container: ClientRect): void {

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -12,7 +12,7 @@ export default class Cursor {
   public static readonly CARET_CONTAINER_CLASS = 'ql-cursor-caret-container';
   public static readonly FLAG_CLASS = 'ql-cursor-flag';
   public static readonly SHOW_FLAG_CLASS = 'show-flag';
-  public static readonly FLAG_FLAP_CLASS = 'ql-cursor-flag-flap';
+  public static readonly FLAG_FLIPPED_CLASS = 'flag-flipped';
   public static readonly NAME_CLASS = 'ql-cursor-name';
   public static readonly HIDDEN_CLASS = 'hidden';
   public static readonly NO_DELAY_CLASS = 'no-delay';
@@ -90,8 +90,11 @@ export default class Cursor {
     this._caretEl.style.left = `${rectangle.left}px`;
     this._caretEl.style.height = `${rectangle.height}px`;
 
-    const flagLeft = Math.min(container.width - flagRect.width, rectangle.left);
-    this._flagEl.style.left = `${flagLeft}px`;
+    this._flagEl.classList.remove(Cursor.FLAG_FLIPPED_CLASS);
+    if (rectangle.left > container.width - flagRect.width) {
+      this._flagEl.classList.add(Cursor.FLAG_FLIPPED_CLASS);
+    }
+    this._flagEl.style.left = `${rectangle.left}px`;
     this._flagEl.style.top = `${rectangle.top}px`;
   }
 

--- a/src/quill-cursors/i-quill-cursors-options.ts
+++ b/src/quill-cursors/i-quill-cursors-options.ts
@@ -5,4 +5,5 @@ export default interface IQuillCursorsOptions {
   hideDelayMs?: number;
   hideSpeedMs?: number;
   transformOnTextChange?: boolean;
+  boundsContainer?: HTMLElement;
 }

--- a/src/quill-cursors/i-quill-cursors-options.ts
+++ b/src/quill-cursors/i-quill-cursors-options.ts
@@ -6,4 +6,5 @@ export default interface IQuillCursorsOptions {
   hideSpeedMs?: number;
   transformOnTextChange?: boolean;
   boundsContainer?: HTMLElement;
+  positionFlag?: (flag: HTMLElement, caretRectangle: ClientRect, container: ClientRect) => void;
 }

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -18,7 +18,7 @@ export default class QuillCursors {
     this._quill = quill;
     this._options = this._setDefaults(options);
     this._container = this._quill.addContainer(this._options.containerClass);
-    this._boundsContainer = this._options.boundsContainer || this._container;
+    this._boundsContainer = this._options.boundsContainer || this._quill.container;
     this._currentSelection = this._quill.getSelection();
 
     this._registerSelectionChangeListeners();

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -10,6 +10,7 @@ export default class QuillCursors {
   private readonly _cursors: { [id: string]: Cursor } = {};
   private readonly _quill: any;
   private readonly _container: HTMLElement;
+  private readonly _boundsContainer: HTMLElement;
   private readonly _options: IQuillCursorsOptions;
   private _currentSelection: IQuillRange;
 
@@ -17,6 +18,7 @@ export default class QuillCursors {
     this._quill = quill;
     this._options = this._setDefaults(options);
     this._container = this._quill.addContainer(this._options.containerClass);
+    this._boundsContainer = this._options.boundsContainer || this._container;
     this._currentSelection = this._quill.getSelection();
 
     this._registerSelectionChangeListeners();
@@ -119,14 +121,15 @@ export default class QuillCursors {
 
     cursor.show();
 
+    const containerRectangle = this._boundsContainer.getBoundingClientRect();
+
     const endBounds = this._quill.getBounds(endIndex);
-    cursor.updateCaret(endBounds);
+    cursor.updateCaret(endBounds, containerRectangle);
 
     const ranges = this._lineRanges(cursor, startLeaf, endLeaf);
     const selectionRectangles = ranges
       .reduce((rectangles, range) => rectangles.concat(Array.from(RangeFix.getClientRects(range))), []);
 
-    const containerRectangle = this._quill.container.getBoundingClientRect();
     cursor.updateSelection(selectionRectangles, containerRectangle);
   }
 

--- a/src/quill-cursors/template.ts
+++ b/src/quill-cursors/template.ts
@@ -7,7 +7,6 @@ const template = `
   </span>
   <div class="${ Cursor.FLAG_CLASS }">
     <small class="${ Cursor.NAME_CLASS }"></small>
-    <span class="${ Cursor.FLAG_FLAP_CLASS }"></span>
   </div>
 `;
 


### PR DESCRIPTION
When the cursor is on the first line the flag can be clipped by container top bound. Same can happen when cursor is near the right edge of the container.

This PR tries to always show it unclipped.
Vertically it shows flag under the cursor if it can't be fit above it.
Horizontally it shifts flag to the left to fit it completely.

PS. I'll add tests and fix other issues if overall PR is ok and acceptable. 