### PR TITLE
Breaking: Remove core Quill styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **BREAKING**: Remove most of the styling we'd previously applied to "core" Quill elements in order to stay as unopinionated as possible
+
 # 2.3.1
 
 - Hide flag immediately when actively toggled

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -42,24 +42,14 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
  * CURSORS *
  ***********/
 
-
-// Core Editor
 .ql-container {
+  // We technically shouldn't need this, because Quill includes this styling
+  // by default, but if it ever gets removed from the core library, or if
+  // consumers aren't using the default styling, then our positioning will break,
+  // so let's add it again just to be sure.
   position: relative;
-  display: flex;
-  flex: 1;
-  flex-direction: column;
   // Make sure we don't show cursors/selection rectangles outside the editor
   overflow: hidden;
-}
-
-.ql-editor {
-  position: relative;
-  position: relative;
-  flex: 1;
-  outline: none;
-  tab-size: 4;
-  white-space: pre-wrap;
 }
 
 .ql-cursor {


### PR DESCRIPTION
This change removes virtually all the styling we do on the "core" Quill
elements, in order to remain as unopinionated as possible.

We explicitly add `position: relative`, which technically isn't needed,
because it's included in Quill's default stylings. However, people are
free to ignore Quill's default stylings, or the styling could be removed
altogether, in which case our `absolute` positioning would break, so
let's explicitly set this just to be safe.

The one exception we have to make is that we need to set
`overflow: hidden` on `.ql-container`, which fixes the issue of
selections appearing outside an editor with a fixed height:
https://github.com/reedsy/quill-cursors/pull/21

Note that this should be acceptable, because even Quill's Bubble theme
displays poor behaviour in this case, so it can be considered a "fix".
Any consumers who care enough can override this, but it at least
provides us with sensible behaviour out-of-the-box.

This is technically a breaking change, in case anyone was relying on our
core styling.