### PR TITLE
⚡️ Fix `ResizeObserver` memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix `ResizeObserver` memory leak
+
 # 3.0.1
 
 - Fix inline image selection


### PR DESCRIPTION
Fixes https://github.com/reedsy/quill-cursors/issues/61

At the moment, the `ResizeObserver` causes a memory leak, because we
never unobserve the Quill container, which then keeps a reference to
that node in memory (even if the node is disconnected from the DOM).

This change tweaks our `ResizeObserver` callback to check if the Quill
container is still connected to the DOM. If not, we unobserve, which
allows the `ResizeObserver` and DOM node to both be correctly garbage-
collected.

However, we can't just leave it there, because consumers may potentially
disconnect their Quill instance, and then reconnect it to the DOM. In
order to address this edge case, we re-register the `ResizeObserver`
whenever an update is made to a cursor, which should start listening
correctly the next time any cursor is updated.

Note that there's still a corner case:

 1. Consumer disconnects Quill from the DOM
 2. `ResizeObserver` stops observing
 3. Consumer reconnects Quill to the DOM
 4. User resizes window (before any updates are made)
 5. Cursors aren't correctly redrawn because the `ResizeObserver` hasn't
    been re-registered

However, this case should be pretty unusual, and is hard to remedy
without even more observers, so let's leave it there. Consumers can
manually fire `cursors.update()` when reconnecting Quill to the DOM to
correctly re-register the `ResizeObserver`.