### PR TITLE
♻️ Change flag opening/closing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 4.0.0
+
+### ⚠ BREAKING CHANGES
+* Moved opening/closing flag logic from CSS to JS with `touchstart`, `mouseover` and `mousemove` events
+  * Get rid of using `.show-flag` class and `:hover` selector for `.ql-cursor-flag`
+  * Added extra `.hover` and `.no-pointer` classes to `.ql-cursor-caret-container` to help with toggling visibility state
+  * `.ql-cursor-caret-container` has `z-index: -1` on touch devices
+  * The «active» area on touch devices depends on `.ql-cursor-caret-container` paddings 
+
 # 3.1.2
 
 - Relax `package.json` `engines`

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -52,6 +52,12 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
   overflow: hidden;
 }
 
+@media (pointer: coarse) {
+  .ql-cursor-caret-container {
+    z-index: -1;
+  }
+}
+
 .ql-cursor {
 
   &.hidden {
@@ -91,26 +97,24 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
     }
   }
 
-  .ql-cursor-flag:hover,
-  .ql-cursor-flag.show-flag,
-  .ql-cursor-caret-container:hover + .ql-cursor-flag {
-    opacity: 1;
-    visibility: visible;
-    transition: none;
-  }
-
   .ql-cursor-flag.no-delay[style] {
     transition-delay: unset !important;
   }
 
   .ql-cursor-caret-container {
+    cursor: text;
     margin-left: -$spacing-sm;
     padding: 0 $spacing-sm;
-    z-index: 1;
 
-    cursor: text;
+    &.hover {
+      + .ql-cursor-flag {
+        opacity: 1;
+        visibility: visible;
+        transition: none;
+      }
+    }
 
-    &:hover {
+    &.no-pointer {
       pointer-events: none;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-cursors",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "description": "A multi cursor module for Quill.",
   "keywords": [
     "quill",
@@ -10,7 +10,8 @@
   ],
   "contributors": [
     "Pedro Machado Santa <pedro.santa@gmail.com>",
-    "Alec Gibson <alec@reedsy.com>"
+    "Alec Gibson <alec@reedsy.com>",
+    "Oleg Petrov <oleg@reedsy.com>"
   ],
   "license": "MIT",
   "main": "dist/quill-cursors.js",

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -167,15 +167,15 @@ describe('Cursor', () => {
   it('toggles the flag display', () => {
     const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
     const element = cursor.build(options);
-    const flag = element.getElementsByClassName(Cursor.FLAG_CLASS)[0];
+    const flag = element.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0];
 
-    expect(flag).not.toHaveClass(Cursor.SHOW_FLAG_CLASS);
+    expect(flag).not.toHaveClass(Cursor.CONTAINER_HOVER_CLASS);
     cursor.toggleFlag(true);
-    expect(flag).toHaveClass(Cursor.SHOW_FLAG_CLASS);
+    expect(flag).toHaveClass(Cursor.CONTAINER_HOVER_CLASS);
     cursor.toggleFlag(false);
-    expect(flag).not.toHaveClass(Cursor.SHOW_FLAG_CLASS);
+    expect(flag).not.toHaveClass(Cursor.CONTAINER_HOVER_CLASS);
     cursor.toggleFlag();
-    expect(flag).toHaveClass(Cursor.SHOW_FLAG_CLASS);
+    expect(flag).toHaveClass(Cursor.CONTAINER_HOVER_CLASS);
   });
 
   it('removes the delay when actively hiding the flag', () => {
@@ -325,6 +325,66 @@ describe('Cursor', () => {
 
       expect(selections.children[0]).toHaveStyle('top: 0px');
       expect(selections.children[0]).toHaveStyle('left: 50px');
+    });
+  });
+
+  describe('mouse move handlers', () => {
+    it('add listener to document by mouse over', () => {
+      jest.spyOn(document, 'addEventListener');
+      const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+      const element = cursor.build(options);
+      const container = element.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0];
+      const mouseEvent = new MouseEvent('mouseover');
+      container.dispatchEvent(mouseEvent);
+      expect(document.addEventListener).toHaveBeenCalled();
+    });
+
+    it('add listeners to document by mouse over', () => {
+      jest.spyOn(document, 'addEventListener');
+      const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+      const element = cursor.build(options);
+      const container = element.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0];
+      const mouseEvent = new MouseEvent('mouseover');
+      container.dispatchEvent(mouseEvent);
+      expect(document.addEventListener).toHaveBeenCalled();
+      jest.runAllTimers();
+      expect(document.addEventListener).toHaveBeenCalledTimes(2);
+    });
+
+    it('keep flag opened if the pointer is near cursor', () => {
+      jest.spyOn(document, 'addEventListener');
+      const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+      const element = cursor.build(options);
+      const container = element.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0];
+      const mouseEvent = new MouseEvent('mouseover', {
+        clientX: 0,
+        clientY: 0,
+      }) as any;
+      const mouseMoveEvent = new MouseEvent('mousemove', {
+        clientX: 0,
+        clientY: 0,
+      }) as any;
+      container.dispatchEvent(mouseEvent);
+      document.dispatchEvent(mouseMoveEvent);
+      expect(container).toHaveClass(Cursor.CONTAINER_NO_POINTER_CLASS);
+    });
+
+    it('hide flag if the pointer is not near cursor', () => {
+      jest.spyOn(document, 'addEventListener');
+      const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+      const element = cursor.build(options);
+      const container = element.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0];
+      const mouseEvent = new MouseEvent('mouseover', {
+        clientX: 10,
+        clientY: 10,
+      }) as any;
+      const mouseMoveEvent = new MouseEvent('mousemove', {
+        clientX: 10,
+        clientY: 10,
+      }) as any;
+      container.dispatchEvent(mouseEvent);
+      document.dispatchEvent(mouseMoveEvent);
+      expect(container).not.toHaveClass(Cursor.CONTAINER_NO_POINTER_CLASS);
     });
   });
 });

--- a/src/quill-cursors/i-coordinates.ts
+++ b/src/quill-cursors/i-coordinates.ts
@@ -1,0 +1,6 @@
+export interface ICoordinates {
+  left: number,
+  top: number,
+  right: number,
+  bottom: number,
+}

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -540,15 +540,49 @@ describe('QuillCursors', () => {
       const cursors = new QuillCursors(quill);
       cursors.createCursor('abc', 'Joe Bloggs', 'red');
 
-      const flag = quill.container.getElementsByClassName(Cursor.FLAG_CLASS)[0];
-      expect(flag).not.toHaveClass(Cursor.SHOW_FLAG_CLASS);
+      const container = quill.container.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0];
+      expect(container).not.toHaveClass(Cursor.CONTAINER_HOVER_CLASS);
       cursors.toggleFlag('abc', true);
-      expect(flag).toHaveClass(Cursor.SHOW_FLAG_CLASS);
+      expect(container).toHaveClass(Cursor.CONTAINER_HOVER_CLASS);
     });
 
     it('does not throw if the cursor does not exist', () => {
       const cursors = new QuillCursors(quill);
       expect(() => cursors.toggleFlag('abc')).not.toThrow();
+    });
+
+    describe('touch', () => {
+      it('toggles near flags by touchstart event', () => {
+        const cursors = new QuillCursors(quill);
+        cursors.createCursor('abc', 'Iron Man', 'red');
+
+        const cursor = cursors.cursors()[0];
+        jest.spyOn(cursor, 'toggleNearCursor');
+
+        const touch = new TouchEvent('touchstart');
+        const editor = quill.container.getElementsByClassName('ql-editor')[0];
+        editor.dispatchEvent(touch);
+        expect(cursor.toggleNearCursor).toBeCalled();
+      });
+
+      it('hide flags after 2 secs', () => {
+        jest.useFakeTimers();
+        const cursors = new QuillCursors(quill);
+        cursors.createCursor('abc', 'Iron Man', 'red');
+
+        const cursor = cursors.cursors()[0];
+        jest.spyOn(cursor, 'toggleNearCursor');
+        jest.spyOn(cursor, 'toggleFlag');
+
+        const touch = new TouchEvent('touchstart');
+        const editor = quill.container.getElementsByClassName('ql-editor')[0];
+        editor.dispatchEvent(touch);
+        expect(cursor.toggleNearCursor).toBeCalled();
+
+        jest.runAllTimers();
+
+        expect(cursor.toggleFlag).toBeCalled();
+      });
     });
   });
 

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -25,6 +25,7 @@ export default class QuillCursors {
   private _isObserving = false;
 
   public constructor(quill: any, options: IQuillCursorsOptions = {}) {
+    this._handleCursorTouch = this._handleCursorTouch.bind(this);
     this.quill = quill;
     this.options = this._setDefaults(options);
     this._container = this.quill.addContainer(this.options.containerClass);
@@ -110,6 +111,14 @@ export default class QuillCursors {
   private _registerDomListeners(): void {
     const editor = this.quill.container.getElementsByClassName('ql-editor')[0];
     editor.addEventListener('scroll', () => this.update());
+    editor.addEventListener('touchstart', this._handleCursorTouch);
+  }
+
+  private _handleCursorTouch(e: MouseEvent): void {
+    this.cursors().forEach((cursor) => {
+      cursor.toggleNearCursor(e.pageX, e.pageY);
+      setTimeout(() => cursor.toggleFlag(false), this.options.hideDelayMs);
+    });
   }
 
   private _registerResizeObserver(): void {


### PR DESCRIPTION
There is the issue with using CSS for opening/closing logic for flags. It's broken on touch devices (which don't trigger the `:hover` styling) (Issue #77). To fix it, we moved all the logic to JS:
- Changed `z-index` to «move» a cursor behind the text. It resolves the issue, when a cursor prevent clicking on the text (even if a user clicks exactly on cursor)
- Added listeners for `mousemove` and `touchstart` with a callback, which shows/closes flags depends on a point position

To achieve it there are added a couple of callbacks to update cursors position and store it in the quill-cursors module. It should be enough to cover all cases for touch and non-touch devices. Also, there is a small throttling for mousemove events to improve performance and decrease amount of callbacks executions