### PR TITLE
👷 Fix broken actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: '14.x'
+        node-version: '16.x'
     - name: Install
       run: npm install
     - name: Build

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^6.6.0",
     "eslint": "^8.8.0",
-    "extract-text-webpack-plugin": "^3.0.2",
     "jest": "^27.4.7",
     "quill": "^1.3.7",
     "quill-delta": "^4.2.2",
@@ -46,7 +45,7 @@
     "ts-jest": "^27.1.3",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.5",
-    "webpack": "^5.68.0",
+    "webpack": "^5.73.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4"
   },


### PR DESCRIPTION
There is a timeout [issue][1] with installing dependencies. It stucks with `fetchMetadata`.
Changing the Node version fixes it.
Additionally, I removed unused `extract-text-webpack-plugin`, which produced conflict webpack version errors

[1]: https://github.com/reedsy/quill-cursors/runs/7019331689