### PR TITLE
🐛 Fix ResizeObserver limit loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+- Fix `ResizeObserver loop limit` error
+- Pin `@typescript-eslint` to v5.41.0
+
 # 4.0.0
 
 ### ⚠ BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-cursors",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A multi cursor module for Quill.",
   "keywords": [
     "quill",

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -97,7 +97,7 @@ describe('QuillCursors', () => {
       expect(ResizeObserver).toHaveBeenCalledTimes(1);
       const callback = (ResizeObserver as any).mock.calls[0][0];
       jest.spyOn(cursors, 'update');
-      callback([{target: {}}]);
+      callback([{target: {isConnected: true}}]);
       expect(cursors.update).toHaveBeenCalledTimes(1);
     });
 

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -129,6 +129,7 @@ export default class QuillCursors {
       if (!entry.target.isConnected) {
         resizeObserver.disconnect();
         this._isObserving = false;
+        return;
       }
       this.update();
     });


### PR DESCRIPTION
After the last Chrome's update to version 109, there is the issue with `ResizeObserver limit loop`, because of infinity loop. It happens because we **always** update cursors, which registers the new observer. Let's return from the function and prevent creating new observer for cases, when it should stop observing