### PR TITLE
📌 Pin `@typescript-eslint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@testing-library/jest-dom": "^5.16.1",
     "@types/jest": "^27.4.0",
     "@types/tinycolor2": "^1.4.3",
+    "@typescript-eslint/eslint-plugin": "=5.41.0",
+    "@typescript-eslint/parser": "=5.41.0",
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^6.6.0",
     "eslint": "^8.8.0",
@@ -49,6 +51,5 @@
     "webpack": "^5.73.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
Upstream changes to `@typescript-eslint` broke the config for our `eslint-config-reedsy` library.

We actually deprecated that library in favour of `@reedsy/eslint-plugin` but that package is currently private.

Until we sort out permissions, this change quickly just pins our version of `@typescript-eslint` to greenify the build.