### PR TITLE
⚡️ Make all event listeners passive

### DIFF
--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -67,7 +67,7 @@ export default class Cursor {
     this._caretEl = caretContainerElement;
     this._flagEl = flagElement;
 
-    caretContainerElement.addEventListener('mouseover', this._setHoverState);
+    caretContainerElement.addEventListener('mouseover', this._setHoverState, {passive: true});
 
     return this._el;
   }
@@ -127,7 +127,7 @@ export default class Cursor {
   }
 
   private _setHoverState(): void {
-    document.addEventListener('mousemove', this._toggleOpenedCursor);
+    document.addEventListener('mousemove', this._toggleOpenedCursor, {passive: true});
   }
 
   private _toggleOpenedCursor(e: MouseEvent): void {

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -70,7 +70,7 @@ describe('QuillCursors', () => {
       const editor = quill.container.getElementsByClassName('ql-editor')[0];
       jest.spyOn(editor, 'addEventListener');
       const cursors = new QuillCursors(quill);
-      expect(editor.addEventListener).toHaveBeenCalledWith('scroll', expect.anything());
+      expect(editor.addEventListener).toHaveBeenCalledWith('scroll', expect.anything(), {passive: true});
 
       jest.spyOn(cursors, 'update');
       const scroll = new Event('scroll');

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -109,9 +109,9 @@ export default class QuillCursors {
   }
 
   private _registerDomListeners(): void {
-    const editor = this.quill.container.getElementsByClassName('ql-editor')[0];
-    editor.addEventListener('scroll', () => this.update());
-    editor.addEventListener('touchstart', this._handleCursorTouch);
+    const editor = this.quill.container.getElementsByClassName('ql-editor')[0] as HTMLElement;
+    editor.addEventListener('scroll', () => this.update(), {passive: true});
+    editor.addEventListener('touchstart', this._handleCursorTouch, {passive: true});
   }
 
   private _handleCursorTouch(e: MouseEvent): void {


### PR DESCRIPTION
Fixes https://github.com/reedsy/quill-cursors/issues/92

If an event listener never invokes `preventDefault()`, it can be marked as [passive][1].

We don't call `preventDefault()` anywhere in our code, so we can safely mark all of our event listeners as passive.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#using_passive_listeners