### PR TITLE
🐛 Support CSS custom properties in `createCursor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.4
+- Support CSS custom properties as input for the `createCursor` method by applying fade via `opacity` instead of modifying the alpha channel.
+
 # 4.0.3
 - Make event listeners passive
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-cursors",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A multi cursor module for Quill.",
   "keywords": [
     "quill",
@@ -30,7 +30,6 @@
     "@reedsy/eslint-plugin": "^0.14.2",
     "@testing-library/jest-dom": "^5.16.1",
     "@types/jest": "^27.4.0",
-    "@types/tinycolor2": "^1.4.3",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
     "clean-webpack-plugin": "^4.0.0",
@@ -44,7 +43,6 @@
     "sass": "^1.49.7",
     "sass-loader": "^12.4.0",
     "style-loader": "^3.3.1",
-    "tinycolor2": "^1.4.2",
     "ts-jest": "^27.1.3",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.5",

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -234,13 +234,15 @@ describe('Cursor', () => {
       expect(selections.children[0]).toHaveStyle('left: 50px');
       expect(selections.children[0]).toHaveStyle('width: 100px');
       expect(selections.children[0]).toHaveStyle('height: 200px');
-      expect(selections.children[0]).toHaveStyle('background-color: rgba(255, 0, 0, 0.3)');
+      expect(selections.children[0]).toHaveStyle('background-color: red');
+      expect(selections.children[0]).toHaveStyle('opacity: 0.3');
 
       expect(selections.children[1]).toHaveStyle('top: 1000px');
       expect(selections.children[1]).toHaveStyle('left: 1050px');
       expect(selections.children[1]).toHaveStyle('width: 200px');
       expect(selections.children[1]).toHaveStyle('height: 300px');
-      expect(selections.children[1]).toHaveStyle('background-color: rgba(255, 0, 0, 0.3)');
+      expect(selections.children[1]).toHaveStyle('background-color: red');
+      expect(selections.children[1]).toHaveStyle('opacity: 0.3');
     });
 
     it('clears the selection if nothing is passed in', () => {

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -1,6 +1,5 @@
 import IQuillCursorsOptions from './i-quill-cursors-options';
 import IQuillRange from './i-range';
-import tinycolor = require('tinycolor2');
 import {ICoordinates} from './i-coordinates';
 
 export default class Cursor {
@@ -171,7 +170,8 @@ export default class Cursor {
     element.style.left = `${selection.left - container.left}px`;
     element.style.width = `${selection.width}px`;
     element.style.height = `${selection.height}px`;
-    element.style.backgroundColor = tinycolor(this.color).setAlpha(0.3).toString();
+    element.style.backgroundColor = this.color;
+    element.style.opacity = '0.3';
 
     return element;
   }


### PR DESCRIPTION
Currently there is an issue when passing a CSS custom property to the `createCursor` method:

<img width="180" alt="image" src="https://github.com/user-attachments/assets/340c7c92-2408-48c2-962d-609e55d62285" />

While the flag and the caret colour are set correctly, modifying the alpha value for the selection block fails. This results in `rgb(0, 0, 0)` as a CSS variable is not a valid input for `tinycolor`.

https://github.com/reedsy/quill-cursors/blob/5524fbb2340bfb7e466e3214793a9a384fef47a5/src/quill-cursors/cursor.ts#L174

This change addresses the issue by applying the fade effect via the `opacity` property instead of manipulating the `alpha` channel.

> [!NOTE]
> This will slightly change functionality, as before the existing opacity would be overwritten (for example, passing `rgba(0, 0, 0, 0.5)` would result in the selection block being `rgba(0, 0, 0, 0.3)`). Now the fade will apply to the existing colour (so the previous example will result in `rgba(0, 0, 0, 0.15)` instead).
>
> This behaviour is more intuitive, especially when working with colours that have alpha values less than `0.3`. Previously, these would result in the fade making the colour stronger instead of lighter.