### PR TITLE
Fix typo: replace --ignore-script with --ignore-scripts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         registry-url: 'https://npm.pkg.github.com'
     - name: Install
       # Skip post-install to avoid malicious scripts stealing PAT
-      run: npm install --ignore-script
+      run: npm install --ignore-scripts
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Post-install


### PR DESCRIPTION
## Summary

- Fixes a typo: `--ignore-script` → `--ignore-scripts` in CI workflows
- `--ignore-script` is not a valid npm flag and is silently ignored
- `--ignore-scripts` (plural) is the correct flag, per the [npm install docs](https://docs.npmjs.com/cli/v10/commands/npm-install#ignore-scripts)

## Test plan

- [ ] Verify CI passes after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)