### PR TITLE
Render selections with the CSS Custom Highlight API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,21 @@ Selections are now rendered with the native
 instead of manually-positioned rectangles ([#98](https://github.com/reedsy/quill-cursors/issues/98)).
 
 * Browser support floor is now Chrome/Edge 111+, Safari 17.2+, Firefox 140+. Older
-  browsers still render carets and flags, but not selections (one console warning).
-* The default cursor template no longer contains `<span class="ql-cursor-selections">`;
-  custom templates may keep it, but it is ignored. `.ql-cursor-selection-block` spans are
-  no longer rendered at all — remove any application CSS targeting that class.
-* Removed `Cursor.SELECTION_CLASS`, `Cursor.SELECTION_BLOCK_CLASS` and
-  `Cursor.SELECTION_ELEMENT_TAG`; `cursor.updateSelection(rects, container)` is replaced
-  by `cursor.setSelectionRange(range: Range | null)`.
-* Block embeds (images, videos) within a remote selection are no longer covered by a
-  tinted rectangle — highlights paint text, matching native selection behaviour.
+  browsers still render carets, flags and block-embed overlays, but not text
+  selections (one console warning).
+* The `<span class="ql-cursor-selections">` element in the cursor template is now only
+  used for tinted overlays over block embeds; text selections no longer create any DOM
+  elements. Templates without the element are tolerated (block embeds just won't be
+  tinted for those cursors).
+* `cursor.updateSelection(rects, container)` is replaced by
+  `cursor.setSelectionRange(range: Range | null)` for text and
+  `cursor.updateEmbedSelections(rects, container)` for block embeds.
+* Inline embeds (e.g. formula markers) within a remote selection are no longer tinted,
+  matching native selection painting; block embeds (e.g. video) still receive a tinted
+  overlay rectangle.
 * Dropped the `rangefix` and `resize-observer-polyfill` dependencies; the bundles are
-  significantly smaller, and scroll/resize now only reposition carets (the browser
-  repaints highlights natively).
+  significantly smaller, and scroll/resize now only reposition carets and embed
+  overlays (the browser repaints highlights natively).
 
 ### Features
 
@@ -28,6 +31,8 @@ instead of manually-positioned rectangles ([#98](https://github.com/reedsy/quill
   Shadow-DOM-aware (the stylesheet is adopted into the editor's actual root).
 * Cursor colors validated via `CSS.supports()` before being written into highlight
   rules; invalid values fall back to `transparent`.
+* Overlapping selections from different cursors stack deterministically
+  (later-created cursors paint on top) via `Highlight.priority`.
 
 # 4.3.0
 - Add `destroy()` method for proper cleanup: removes event listeners, disconnects ResizeObserver, clears pending timers, and removes the cursor container from the DOM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,18 @@ Selections are now rendered with the native
 instead of manually-positioned rectangles ([#98](https://github.com/reedsy/quill-cursors/issues/98)).
 
 * Browser support floor is now Chrome/Edge 111+, Safari 17.2+, Firefox 140+. Older
-  browsers still render carets, flags and block-embed overlays, but not text
-  selections (one console warning).
+  browsers still render carets, flags and embed overlays, but not text selections
+  (one console warning).
 * The `<span class="ql-cursor-selections">` element in the cursor template is now only
-  used for tinted overlays over block embeds; text selections no longer create any DOM
-  elements. Templates without the element are tolerated (block embeds just won't be
-  tinted for those cursors).
+  used for tinted overlays over embeds; text selections no longer create any DOM
+  elements. Templates without the element are tolerated (embeds just won't be tinted
+  for those cursors).
 * `cursor.updateSelection(rects, container)` is replaced by
   `cursor.setSelectionRange(range: Range | null)` for text and
-  `cursor.updateEmbedSelections(rects, container)` for block embeds.
-* Inline embeds (e.g. formula markers) within a remote selection are no longer tinted,
-  matching native selection painting; block embeds (e.g. video) still receive a tinted
-  overlay rectangle.
+  `cursor.updateEmbedSelections(rects, container)` for embeds.
+* Embeds within a remote selection — inline (e.g. images) or block (e.g. videos) — are
+  covered by a tinted overlay rectangle, since the Highlight API itself only paints
+  text.
 * Dropped the `rangefix` and `resize-observer-polyfill` dependencies; the bundles are
   significantly smaller, and scroll/resize now only reposition carets and embed
   overlays (the browser repaints highlights natively).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+# 5.0.0
+
+### ⚠ BREAKING CHANGES
+
+Selections are now rendered with the native
+[CSS Custom Highlight API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API)
+instead of manually-positioned rectangles ([#98](https://github.com/reedsy/quill-cursors/issues/98)).
+
+* Browser support floor is now Chrome/Edge 111+, Safari 17.2+, Firefox 140+. Older
+  browsers still render carets and flags, but not selections (one console warning).
+* The default cursor template no longer contains `<span class="ql-cursor-selections">`;
+  custom templates may keep it, but it is ignored. `.ql-cursor-selection-block` spans are
+  no longer rendered at all — remove any application CSS targeting that class.
+* Removed `Cursor.SELECTION_CLASS`, `Cursor.SELECTION_BLOCK_CLASS` and
+  `Cursor.SELECTION_ELEMENT_TAG`; `cursor.updateSelection(rects, container)` is replaced
+  by `cursor.setSelectionRange(range: Range | null)`.
+* Block embeds (images, videos) within a remote selection are no longer covered by a
+  tinted rectangle — highlights paint text, matching native selection behaviour.
+* Dropped the `rangefix` and `resize-observer-polyfill` dependencies; the bundles are
+  significantly smaller, and scroll/resize now only reposition carets (the browser
+  repaints highlights natively).
+
+### Features
+
+* `cursor.highlightName` exposes the `CSS.highlights` registry name, so applications
+  can layer extra styling via `::highlight(<name>)`.
+* Selection highlight styles use constructable stylesheets: CSP-safe in both bundles,
+  Shadow-DOM-aware (the stylesheet is adopted into the editor's actual root).
+* Cursor colors validated via `CSS.supports()` before being written into highlight
+  rules; invalid values fall back to `transparent`.
+
 # 4.3.0
 - Add `destroy()` method for proper cleanup: removes event listeners, disconnects ResizeObserver, clears pending timers, and removes the cursor container from the DOM
 - Auto-teardown: when the Quill container is removed from the DOM, the module detects this on the next Quill event and calls `destroy()` automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Selections are now rendered with the native
 [CSS Custom Highlight API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API)
 instead of manually-positioned rectangles ([#98](https://github.com/reedsy/quill-cursors/issues/98)).
 
-* Browser support floor is now Chrome/Edge 111+, Safari 17.2+, Firefox 140+. Older
+* Browser support floor is now Chrome/Edge 122+, Safari 17.2+, Firefox 140+. Older
   browsers still render carets, flags and embed overlays, but not text selections
   (one console warning).
 * The `<span class="ql-cursor-selections">` element in the cursor template is now only
@@ -33,6 +33,8 @@ instead of manually-positioned rectangles ([#98](https://github.com/reedsy/quill
   rules; invalid values fall back to `transparent`.
 * Overlapping selections from different cursors stack deterministically
   (later-created cursors paint on top) via `Highlight.priority`.
+* The selection fade is themable via the `--ql-cursor-selection-fade` CSS variable
+  (default `0.3`), shared by text highlights and embed overlays.
 
 # 4.3.0
 - Add `destroy()` method for proper cleanup: removes event listeners, disconnects ResizeObserver, clears pending timers, and removes the cursor container from the DOM

--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ A collaborative editing module for the [Quill](https://github.com/quilljs/quill)
 npm install quill-cursors --save
 ```
 
+## Browser support
+
+Since v5.0.0, selection ranges are painted by the browser using the native
+[CSS Custom Highlight API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API),
+which requires:
+
+| Chrome / Edge | Safari | Firefox |
+|---|---|---|
+| 111+ | 17.2+ | 140+ |
+
+In older browsers, `quill-cursors` degrades gracefully: carets and name flags
+still work (they are plain DOM elements), selection ranges are simply not
+drawn, and a single warning is logged to the console. If you need selection
+rendering in older browsers, stay on the 4.x release line.
+
+Cursor colors using CSS custom properties (e.g. `var(--user-color)`) resolve
+inside highlight rules in Chrome/Edge 122+; Safari and Firefox support them
+from the same versions as the API itself.
+
 ## Usage
 
 `quill-cursors` is a Quill module that exposes a number of methods to help display other users' cursors for
@@ -66,7 +85,7 @@ npm start
 
 The `quill-cursors` module has the following optional configuration:
 
-  - `template` _string_: override the default HTML template used for a cursor
+  - `template` _string_: override the default HTML template used for a cursor (since v5, a selections element is no longer used and may be omitted)
   - `containerClass` _string_ (default: `ql-cursors`): the CSS class to add to the cursors container
   - `hideDelayMs` _number_ (default: `3000`): number of milliseconds to show the username flag before hiding it
   - `hideSpeedMs` _number_ (default: `400`): the duration of the flag hiding animation in milliseconds
@@ -143,8 +162,21 @@ Returns a `Cursor` object:
   name: string;
   color: string;
   range: Range; // See https://quilljs.com/docs/api/#selection-change
+  highlightName: string; // The name registered in CSS.highlights for this cursor's selection
 }
 ```
+
+The selection is painted via [`::highlight(<highlightName>)`](https://developer.mozilla.org/en-US/docs/Web/CSS/::highlight).
+You can layer your own styling on top from your application CSS, e.g.:
+
+```css
+::highlight(ql-cursor-highlight-0) {
+  text-decoration: underline;
+}
+```
+
+The numeric suffix depends on cursor creation order — always read the actual
+name from `cursor.highlightName` rather than hard-coding it.
 
 #### `moveCursor`
 
@@ -266,6 +298,12 @@ link.rel = 'stylesheet';
 link.href = 'path/to/quill-cursors.min.css';
 shadowRoot.appendChild(link);
 ```
+
+Selection highlights are styled with
+[constructable stylesheets](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet)
+adopted into the editor's document (or shadow root). These are not inline
+styles, so they work under strict CSP in **both** bundles, and automatically
+end up in the correct shadow root.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ which requires:
 |---|---|---|
 | 111+ | 17.2+ | 140+ |
 
-In older browsers, `quill-cursors` degrades gracefully: carets and name flags
-still work (they are plain DOM elements), selection ranges are simply not
-drawn, and a single warning is logged to the console. If you need selection
-rendering in older browsers, stay on the 4.x release line.
+In older browsers, `quill-cursors` degrades gracefully: carets, name flags and
+block-embed overlays still work (they are plain DOM elements), text selection
+ranges are simply not drawn, and a single warning is logged to the console.
+If you need text selection rendering in older browsers, stay on the 4.x
+release line.
 
 Cursor colors using CSS custom properties (e.g. `var(--user-color)`) resolve
 inside highlight rules in Chrome/Edge 122+; Safari and Firefox support them
@@ -85,7 +86,7 @@ npm start
 
 The `quill-cursors` module has the following optional configuration:
 
-  - `template` _string_: override the default HTML template used for a cursor (since v5, a selections element is no longer used and may be omitted)
+  - `template` _string_: override the default HTML template used for a cursor (since v5, the selections element is only used for block-embed overlays and may be omitted)
   - `containerClass` _string_ (default: `ql-cursors`): the CSS class to add to the cursors container
   - `hideDelayMs` _number_ (default: `3000`): number of milliseconds to show the username flag before hiding it
   - `hideSpeedMs` _number_ (default: `400`): the duration of the flag hiding animation in milliseconds

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ which requires:
 
 | Chrome / Edge | Safari | Firefox |
 |---|---|---|
-| 111+ | 17.2+ | 140+ |
+| 122+ | 17.2+ | 140+ |
 
 In older browsers, `quill-cursors` degrades gracefully: carets, name flags and
 embed overlays still work (they are plain DOM elements), text selection
@@ -30,9 +30,10 @@ ranges are simply not drawn, and a single warning is logged to the console.
 If you need text selection rendering in older browsers, stay on the 4.x
 release line.
 
-Cursor colors using CSS custom properties (e.g. `var(--user-color)`) resolve
-inside highlight rules in Chrome/Edge 122+; Safari and Firefox support them
-from the same versions as the API itself.
+How faded remote selections look is controlled by a single CSS variable,
+`--ql-cursor-selection-fade` (default `0.3`), used by both the text highlight
+and the embed overlays. Override it on `.ql-container` to theme the fade.
+Cursor colors may also be CSS custom properties (e.g. `var(--user-color)`).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ which requires:
 | 111+ | 17.2+ | 140+ |
 
 In older browsers, `quill-cursors` degrades gracefully: carets, name flags and
-block-embed overlays still work (they are plain DOM elements), text selection
+embed overlays still work (they are plain DOM elements), text selection
 ranges are simply not drawn, and a single warning is logged to the console.
 If you need text selection rendering in older browsers, stay on the 4.x
 release line.
@@ -86,7 +86,7 @@ npm start
 
 The `quill-cursors` module has the following optional configuration:
 
-  - `template` _string_: override the default HTML template used for a cursor (since v5, the selections element is only used for block-embed overlays and may be omitted)
+  - `template` _string_: override the default HTML template used for a cursor (since v5, the selections element is only used for embed overlays and may be omitted)
   - `containerClass` _string_ (default: `ql-cursors`): the CSS class to add to the cursors container
   - `hideDelayMs` _number_ (default: `3000`): number of milliseconds to show the username flag before hiding it
   - `hideSpeedMs` _number_ (default: `400`): the duration of the flag hiding animation in milliseconds

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -133,5 +133,6 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
   .ql-cursor-selection-block {
     position: absolute;
     pointer-events: none;
+    opacity: 0.3;
   }
 }

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -43,6 +43,9 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
  ***********/
 
 .ql-container {
+  // Single knob for how faded remote selections look; read by the embed
+  // overlay blocks and by the ::highlight() rules built in JS.
+  --ql-cursor-selection-fade: 0.3;
   // We technically shouldn't need this, because Quill includes this styling
   // by default, but if it ever gets removed from the core library, or if
   // consumers aren't using the default styling, then our positioning will break,
@@ -133,6 +136,6 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
   .ql-cursor-selection-block {
     position: absolute;
     pointer-events: none;
-    opacity: 0.3;
+    opacity: var(--ql-cursor-selection-fade);
   }
 }

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -129,8 +129,7 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
     }
   }
 
-  // Tinted overlays for block embeds included in a remote selection; text is
-  // tinted via the CSS Custom Highlight API instead.
+  // Tinted overlays for embeds included in a remote selection
   .ql-cursor-selection-block {
     position: absolute;
     pointer-events: none;

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -48,7 +48,7 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
   // consumers aren't using the default styling, then our positioning will break,
   // so let's add it again just to be sure.
   position: relative;
-  // Make sure we don't show carets or flags outside the editor
+  // Make sure we don't show carets, flags or embed overlays outside the editor
   overflow: hidden;
 }
 
@@ -127,5 +127,12 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
 
       background-color: attr(data-color);
     }
+  }
+
+  // Tinted overlays for block embeds included in a remote selection; text is
+  // tinted via the CSS Custom Highlight API instead.
+  .ql-cursor-selection-block {
+    position: absolute;
+    pointer-events: none;
   }
 }

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -136,6 +136,6 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
   .ql-cursor-selection-block {
     position: absolute;
     pointer-events: none;
-    opacity: var(--ql-cursor-selection-fade);
+    opacity: var(--ql-cursor-selection-fade, 0.3);
   }
 }

--- a/assets/quill-cursors.scss
+++ b/assets/quill-cursors.scss
@@ -48,7 +48,7 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
   // consumers aren't using the default styling, then our positioning will break,
   // so let's add it again just to be sure.
   position: relative;
-  // Make sure we don't show cursors/selection rectangles outside the editor
+  // Make sure we don't show carets or flags outside the editor
   overflow: hidden;
 }
 
@@ -127,10 +127,5 @@ $transition-func: cubic-bezier(0.250, 0.460, 0.450, 0.940);
 
       background-color: attr(data-color);
     }
-  }
-
-  .ql-cursor-selection-block {
-    position: absolute;
-    pointer-events: none;
   }
 }

--- a/example/main.js
+++ b/example/main.js
@@ -8,10 +8,8 @@ const CURSOR_LATENCY = 1000;
 // text changes.
 const TEXT_LATENCY = 500;
 
-// The default snow toolbar, plus image and video controls for checking how
-// remote selections cover embeds: image inserts an INLINE embed, video a
-// BLOCK embed — both are tinted with an overlay rectangle when selected,
-// since the Highlight API itself only paints text.
+// Default snow toolbar plus image (inline embed) and video (block embed)
+// controls, for checking how remote selections cover embeds.
 const TOOLBAR = [
   [{header: ['1', '2', '3', false]}],
   ['bold', 'italic', 'underline', 'link'],

--- a/example/main.js
+++ b/example/main.js
@@ -30,7 +30,7 @@ const cursorsOne = quillOne.getModule('cursors');
 const cursorsTwo = quillTwo.getModule('cursors');
 
 cursorsOne.createCursor('cursor', 'User 2', 'blue');
-cursorsTwo.createCursor('cursor', 'User 1', 'red');
+cursorsTwo.createCursor('cursor', 'User 1', 'var(--demo-cursor-color)');
 
 function textChangeHandler(quill) {
   return function(delta, oldContents, source) {

--- a/example/main.js
+++ b/example/main.js
@@ -8,12 +8,24 @@ const CURSOR_LATENCY = 1000;
 // text changes.
 const TEXT_LATENCY = 500;
 
+// The default snow toolbar, plus embed controls: image inserts an INLINE
+// embed (not tinted by remote selections, matching native selection
+// painting), video inserts a BLOCK embed (tinted with an overlay rectangle).
+const TOOLBAR = [
+  [{header: ['1', '2', '3', false]}],
+  ['bold', 'italic', 'underline', 'link'],
+  [{list: 'ordered'}, {list: 'bullet'}],
+  ['image', 'video'],
+  ['clean'],
+];
+
 const quillOne = new Quill('#editor-one', {
   theme: 'snow',
   modules: {
     cursors: {
       transformOnTextChange: true,
     },
+    toolbar: TOOLBAR,
   },
 });
 
@@ -23,6 +35,7 @@ const quillTwo = new Quill('#editor-two', {
     cursors: {
       transformOnTextChange: true,
     },
+    toolbar: TOOLBAR,
   },
 });
 

--- a/example/main.js
+++ b/example/main.js
@@ -8,9 +8,10 @@ const CURSOR_LATENCY = 1000;
 // text changes.
 const TEXT_LATENCY = 500;
 
-// The default snow toolbar, plus embed controls: image inserts an INLINE
-// embed (not tinted by remote selections, matching native selection
-// painting), video inserts a BLOCK embed (tinted with an overlay rectangle).
+// The default snow toolbar, plus image and video controls for checking how
+// remote selections cover embeds: image inserts an INLINE embed, video a
+// BLOCK embed — both are tinted with an overlay rectangle when selected,
+// since the Highlight API itself only paints text.
 const TOOLBAR = [
   [{header: ['1', '2', '3', false]}],
   ['bold', 'italic', 'underline', 'link'],

--- a/example/styles.css
+++ b/example/styles.css
@@ -1,3 +1,8 @@
+:root {
+  /* Used as a cursor color to demonstrate CSS custom property support */
+  --demo-cursor-color: rebeccapurple;
+}
+
 html, body {
   font-family: Helvetica, Arial, sans-serif;
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/jest.setup.ts'],
+  coveragePathIgnorePatterns: ['/node_modules/', '<rootDir>/src/jest.setup.ts'],
   coverageThreshold: {
     global: {
       branches: 100,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-cursors",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "description": "A multi cursor module for Quill.",
   "keywords": [
     "quill",
@@ -53,8 +53,6 @@
     "jest": "^27.4.7",
     "quill": "^1.3.7",
     "quill-delta": "^4.2.2",
-    "rangefix": "^0.2.10",
-    "resize-observer-polyfill": "^1.5.1",
     "sass": "^1.49.7",
     "sass-loader": "^12.4.0",
     "style-loader": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@reedsy/eslint-plugin": "^0.14.2",
     "@testing-library/jest-dom": "^5.16.1",
     "@types/jest": "^27.4.0",
+    "@types/node": "25.3.1",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
     "css-loader": "^6.6.0",

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -1,0 +1,73 @@
+// jsdom does not implement the CSS Custom Highlight API, constructable
+// stylesheets, adoptedStyleSheets or ResizeObserver. These minimal stand-ins
+// let the unit tests exercise the code paths that use them.
+
+class HighlightStub {
+  public readonly ranges = new Set<unknown>();
+  public priority = 0;
+
+  public constructor(...ranges: unknown[]) {
+    ranges.forEach((range) => this.ranges.add(range));
+  }
+
+  public get size(): number {
+    return this.ranges.size;
+  }
+
+  public add(range: unknown): HighlightStub {
+    this.ranges.add(range);
+    return this;
+  }
+
+  public delete(range: unknown): boolean {
+    return this.ranges.delete(range);
+  }
+
+  public has(range: unknown): boolean {
+    return this.ranges.has(range);
+  }
+
+  public clear(): void {
+    this.ranges.clear();
+  }
+}
+
+class CSSStyleSheetStub {
+  public cssText = '';
+
+  public replaceSync(text: string): void {
+    this.cssText = text;
+  }
+}
+
+class ResizeObserverStub {
+  public observe(): void {
+    // no-op
+  }
+
+  public unobserve(): void {
+    // no-op
+  }
+
+  public disconnect(): void {
+    // no-op
+  }
+}
+
+(globalThis as any).Highlight = HighlightStub;
+(globalThis as any).CSS = Object.assign((globalThis as any).CSS ?? {}, {highlights: new Map()});
+(globalThis as any).CSSStyleSheet = CSSStyleSheetStub;
+(globalThis as any).ResizeObserver = ResizeObserverStub;
+
+[Document.prototype, ShadowRoot.prototype].forEach((proto) => {
+  Object.defineProperty(proto, 'adoptedStyleSheets', {
+    configurable: true,
+    writable: true,
+    value: [],
+  });
+});
+
+beforeEach(() => {
+  (CSS as any).highlights.clear();
+  (document as any).adoptedStyleSheets = [];
+});

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -34,6 +34,7 @@ class HighlightStub {
 
 class CSSStyleSheetStub {
   public cssText = '';
+  public disabled = false;
 
   public replaceSync(text: string): void {
     this.cssText = text;

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -63,7 +63,7 @@ class ResizeObserverStub {
 (globalThis as any).ResizeObserver = ResizeObserverStub;
 
 // Production code mutates adoptedStyleSheets in place (push/splice), so each
-// document or shadow root must get its OWN array on first access — a shared
+// document or shadow root must get its own array on first access; a shared
 // prototype default would leak sheets between instances and tests.
 [Document.prototype, ShadowRoot.prototype].forEach((proto) => {
   Object.defineProperty(proto, 'adoptedStyleSheets', {

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -55,15 +55,27 @@ class ResizeObserverStub {
 }
 
 (globalThis as any).Highlight = HighlightStub;
-(globalThis as any).CSS = Object.assign((globalThis as any).CSS ?? {}, {highlights: new Map()});
+(globalThis as any).CSS = Object.assign((globalThis as any).CSS ?? {}, {
+  highlights: new Map(),
+  supports: (): boolean => true,
+});
 (globalThis as any).CSSStyleSheet = CSSStyleSheetStub;
 (globalThis as any).ResizeObserver = ResizeObserverStub;
 
+// Production code mutates adoptedStyleSheets in place (push/splice), so each
+// document or shadow root must get its OWN array on first access — a shared
+// prototype default would leak sheets between instances and tests.
 [Document.prototype, ShadowRoot.prototype].forEach((proto) => {
   Object.defineProperty(proto, 'adoptedStyleSheets', {
     configurable: true,
-    writable: true,
-    value: [],
+    get(): any[] {
+      const value: any[] = [];
+      Object.defineProperty(this, 'adoptedStyleSheets', {configurable: true, writable: true, value});
+      return value;
+    },
+    set(value: any[]) {
+      Object.defineProperty(this, 'adoptedStyleSheets', {configurable: true, writable: true, value});
+    },
   });
 });
 

--- a/src/quill-cursors/cursor-highlight.spec.ts
+++ b/src/quill-cursors/cursor-highlight.spec.ts
@@ -102,7 +102,6 @@ describe('CursorHighlight', () => {
         '{ background-color: color-mix(in srgb, transparent 30%, transparent); }',
       );
     });
-
   });
 
   describe('setRange', () => {

--- a/src/quill-cursors/cursor-highlight.spec.ts
+++ b/src/quill-cursors/cursor-highlight.spec.ts
@@ -88,7 +88,10 @@ describe('CursorHighlight', () => {
 
       expect((CSS as any).supports).toHaveBeenCalledWith('background-color', 'var(--user-color)');
       expect((document as any).adoptedStyleSheets[0].cssText)
-        .toContain('color-mix(in srgb, var(--user-color) 30%, transparent)');
+        .toContain(
+          'color-mix(in srgb, var(--user-color) ' +
+          'calc(var(--ql-cursor-selection-fade, 0.3) * 100%), transparent)',
+        );
     });
 
     it('replaces colors that fail validation with transparent', () => {
@@ -98,8 +101,8 @@ describe('CursorHighlight', () => {
       highlight.setRange(document.createRange(), document);
 
       expect((document as any).adoptedStyleSheets[0].cssText).toBe(
-        `::highlight(${ highlight.name }) ` +
-        '{ background-color: color-mix(in srgb, transparent 30%, transparent); }',
+        `::highlight(${ highlight.name }) { background-color: color-mix(in srgb, ` +
+        'transparent calc(var(--ql-cursor-selection-fade, 0.3) * 100%), transparent); }',
       );
     });
   });
@@ -139,7 +142,7 @@ describe('CursorHighlight', () => {
       expect(registered.size).toBe(0);
     });
 
-    it('adopts a stylesheet fading the cursor color to 30%', () => {
+    it('adopts a stylesheet fading the cursor color', () => {
       const highlight = new CursorHighlight('red');
 
       highlight.setRange(document.createRange(), document);
@@ -147,7 +150,10 @@ describe('CursorHighlight', () => {
       const sheets: any[] = (document as any).adoptedStyleSheets;
       expect(sheets).toHaveLength(1);
       expect(sheets[0].cssText)
-        .toBe(`::highlight(${ highlight.name }) { background-color: color-mix(in srgb, red 30%, transparent); }`);
+        .toBe(
+          `::highlight(${ highlight.name }) { background-color: color-mix(in srgb, ` +
+          'red calc(var(--ql-cursor-selection-fade, 0.3) * 100%), transparent); }',
+        );
     });
 
     it('adopts the stylesheet only once', () => {

--- a/src/quill-cursors/cursor-highlight.spec.ts
+++ b/src/quill-cursors/cursor-highlight.spec.ts
@@ -43,6 +43,12 @@ describe('CursorHighlight', () => {
       expect(first.name).not.toBe(second.name);
     });
 
+    it('reserves the name in the registry at construction', () => {
+      const highlight = new CursorHighlight('red');
+
+      expect((CSS as any).highlights.has(highlight.name)).toBe(true);
+    });
+
     it('skips names already taken in the registry', () => {
       const current = new CursorHighlight('red');
       const nextNumber = Number(current.name.split('-').pop()) + 1;
@@ -231,6 +237,47 @@ describe('CursorHighlight', () => {
     it('is safe to call before any range is set', () => {
       const highlight = new CursorHighlight('red');
       expect(() => highlight.clear()).not.toThrow();
+    });
+
+    it('is safe to call after detach', () => {
+      const highlight = new CursorHighlight('red');
+      highlight.detach();
+
+      expect(() => highlight.clear()).not.toThrow();
+    });
+  });
+
+  describe('setVisible', () => {
+    it('toggles the stylesheet instead of dropping the ranges', () => {
+      const highlight = new CursorHighlight('red');
+      const range = document.createRange();
+      highlight.setRange(range, document);
+
+      highlight.setVisible(false);
+
+      const sheets: any[] = (document as any).adoptedStyleSheets;
+      expect(sheets[0].disabled).toBe(true);
+      expect((CSS as any).highlights.get(highlight.name).has(range)).toBe(true);
+
+      highlight.setVisible(true);
+
+      expect(sheets[0].disabled).toBe(false);
+    });
+
+    it('is safe to call before any range is set', () => {
+      const highlight = new CursorHighlight('red');
+      expect(() => highlight.setVisible(false)).not.toThrow();
+    });
+
+    it('re-enables the stylesheet on detach for later reuse', () => {
+      const highlight = new CursorHighlight('red');
+      highlight.setRange(document.createRange(), document);
+      highlight.setVisible(false);
+      highlight.detach();
+
+      highlight.setRange(document.createRange(), document);
+
+      expect((document as any).adoptedStyleSheets[0].disabled).toBe(false);
     });
   });
 

--- a/src/quill-cursors/cursor-highlight.spec.ts
+++ b/src/quill-cursors/cursor-highlight.spec.ts
@@ -1,0 +1,311 @@
+import CursorHighlight from './cursor-highlight';
+
+describe('CursorHighlight', () => {
+  beforeEach(() => {
+    (CursorHighlight as any)._hasWarnedUnsupported = false;
+  });
+
+  describe('isSupported', () => {
+    it('returns true when the Highlight API is available', () => {
+      expect(CursorHighlight.isSupported()).toBe(true);
+    });
+
+    it('returns false without the Highlight constructor', () => {
+      withoutGlobal('Highlight', () => {
+        expect(CursorHighlight.isSupported()).toBe(false);
+      });
+    });
+
+    it('returns false without the CSS global', () => {
+      withoutGlobal('CSS', () => {
+        expect(CursorHighlight.isSupported()).toBe(false);
+      });
+    });
+
+    it('returns false without CSS.highlights', () => {
+      const css = (globalThis as any).CSS;
+      (globalThis as any).CSS = {};
+      try {
+        expect(CursorHighlight.isSupported()).toBe(false);
+      } finally {
+        (globalThis as any).CSS = css;
+      }
+    });
+  });
+
+  describe('name', () => {
+    it('allocates a unique name per highlight', () => {
+      const first = new CursorHighlight('red');
+      const second = new CursorHighlight('red');
+
+      expect(first.name).toMatch(/^ql-cursor-highlight-\d+$/);
+      expect(second.name).toMatch(/^ql-cursor-highlight-\d+$/);
+      expect(first.name).not.toBe(second.name);
+    });
+
+    it('skips names already taken in the registry', () => {
+      const current = new CursorHighlight('red');
+      const nextNumber = Number(current.name.split('-').pop()) + 1;
+      const takenName = `${ CursorHighlight.NAME_PREFIX }-${ nextNumber }`;
+      (CSS as any).highlights.set(takenName, new Highlight());
+
+      const next = new CursorHighlight('red');
+
+      expect(next.name).not.toBe(takenName);
+      expect(next.name).toMatch(/^ql-cursor-highlight-\d+$/);
+    });
+
+    it('allocates names when the registry is unavailable', () => {
+      const css = (globalThis as any).CSS;
+      (globalThis as any).CSS = {};
+      try {
+        const highlight = new CursorHighlight('red');
+        expect(highlight.name).toMatch(/^ql-cursor-highlight-\d+$/);
+      } finally {
+        (globalThis as any).CSS = css;
+      }
+    });
+  });
+
+  describe('color sanitisation', () => {
+    afterEach(() => {
+      delete (CSS as any).supports;
+    });
+
+    it('keeps colors that pass CSS.supports validation', () => {
+      (CSS as any).supports = jest.fn().mockReturnValue(true);
+      const highlight = new CursorHighlight('var(--user-color)');
+
+      highlight.setRange(document.createRange(), document);
+
+      expect((CSS as any).supports).toHaveBeenCalledWith('background-color', 'var(--user-color)');
+      expect((document as any).adoptedStyleSheets[0].cssText)
+        .toContain('color-mix(in srgb, var(--user-color) 30%, transparent)');
+    });
+
+    it('replaces colors that fail validation with transparent', () => {
+      (CSS as any).supports = jest.fn().mockReturnValue(false);
+      const highlight = new CursorHighlight('red; } * { background: red; }');
+
+      highlight.setRange(document.createRange(), document);
+
+      expect((document as any).adoptedStyleSheets[0].cssText).toBe(
+        `::highlight(${ highlight.name }) ` +
+        '{ background-color: color-mix(in srgb, transparent 30%, transparent); }',
+      );
+    });
+
+    it('trusts the color when CSS.supports is unavailable', () => {
+      const highlight = new CursorHighlight('red');
+
+      highlight.setRange(document.createRange(), document);
+
+      expect((document as any).adoptedStyleSheets[0].cssText).toContain('red');
+    });
+
+    it('trusts the color when the CSS global is unavailable', () => {
+      let highlight: CursorHighlight;
+      withoutGlobal('CSS', () => {
+        highlight = new CursorHighlight('red');
+      });
+
+      highlight.setRange(document.createRange(), document);
+
+      expect((document as any).adoptedStyleSheets[0].cssText).toContain('red');
+    });
+  });
+
+  describe('setRange', () => {
+    it('registers the highlight and adds the range', () => {
+      const highlight = new CursorHighlight('red');
+      const range = document.createRange();
+
+      highlight.setRange(range, document);
+
+      const registered: any = (CSS as any).highlights.get(highlight.name);
+      expect(registered.has(range)).toBe(true);
+      expect(registered.size).toBe(1);
+    });
+
+    it('replaces any previous range', () => {
+      const highlight = new CursorHighlight('red');
+      const firstRange = document.createRange();
+      const secondRange = document.createRange();
+
+      highlight.setRange(firstRange, document);
+      highlight.setRange(secondRange, document);
+
+      const registered: any = (CSS as any).highlights.get(highlight.name);
+      expect(registered.has(firstRange)).toBe(false);
+      expect(registered.has(secondRange)).toBe(true);
+    });
+
+    it('empties the highlight when passed null', () => {
+      const highlight = new CursorHighlight('red');
+      highlight.setRange(document.createRange(), document);
+
+      highlight.setRange(null, document);
+
+      const registered: any = (CSS as any).highlights.get(highlight.name);
+      expect(registered.size).toBe(0);
+    });
+
+    it('adopts a stylesheet fading the cursor color to 30%', () => {
+      const highlight = new CursorHighlight('red');
+
+      highlight.setRange(document.createRange(), document);
+
+      const sheets: any[] = (document as any).adoptedStyleSheets;
+      expect(sheets).toHaveLength(1);
+      expect(sheets[0].cssText)
+        .toBe(`::highlight(${ highlight.name }) { background-color: color-mix(in srgb, red 30%, transparent); }`);
+    });
+
+    it('adopts the stylesheet only once', () => {
+      const highlight = new CursorHighlight('red');
+
+      highlight.setRange(document.createRange(), document);
+      highlight.setRange(document.createRange(), document);
+
+      expect((document as any).adoptedStyleSheets).toHaveLength(1);
+    });
+
+    it('adopts the stylesheet into a shadow root', () => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const shadowRoot = host.attachShadow({mode: 'open'});
+      (shadowRoot as any).adoptedStyleSheets = [];
+      const highlight = new CursorHighlight('red');
+
+      highlight.setRange(document.createRange(), shadowRoot);
+
+      expect((shadowRoot as any).adoptedStyleSheets).toHaveLength(1);
+      expect((document as any).adoptedStyleSheets).toHaveLength(0);
+      document.body.removeChild(host);
+    });
+
+    it('moves the stylesheet when the root changes', () => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const shadowRoot = host.attachShadow({mode: 'open'});
+      (shadowRoot as any).adoptedStyleSheets = [];
+      const highlight = new CursorHighlight('red');
+
+      highlight.setRange(document.createRange(), document);
+      highlight.setRange(document.createRange(), shadowRoot);
+
+      expect((document as any).adoptedStyleSheets).toHaveLength(0);
+      expect((shadowRoot as any).adoptedStyleSheets).toHaveLength(1);
+      document.body.removeChild(host);
+    });
+
+    it('still registers the highlight for elements outside a document', () => {
+      const highlight = new CursorHighlight('red');
+      const detached = document.createElement('div');
+
+      highlight.setRange(document.createRange(), detached.getRootNode());
+
+      expect((CSS as any).highlights.has(highlight.name)).toBe(true);
+      expect((document as any).adoptedStyleSheets).toHaveLength(0);
+    });
+
+    it('does nothing when the Highlight API is unsupported', () => {
+      const highlight = new CursorHighlight('red');
+      withoutGlobal('Highlight', () => {
+        highlight.setRange(document.createRange(), document);
+      });
+
+      expect((CSS as any).highlights.size).toBe(0);
+      expect((document as any).adoptedStyleSheets).toHaveLength(0);
+    });
+
+    it('re-registers after detach when setRange is called again', () => {
+      const highlight = new CursorHighlight('red');
+      highlight.setRange(document.createRange(), document);
+      highlight.detach();
+
+      highlight.setRange(document.createRange(), document);
+
+      expect((CSS as any).highlights.has(highlight.name)).toBe(true);
+      expect((document as any).adoptedStyleSheets).toHaveLength(1);
+    });
+  });
+
+  describe('clear', () => {
+    it('empties the ranges without unregistering the highlight', () => {
+      const highlight = new CursorHighlight('red');
+      highlight.setRange(document.createRange(), document);
+
+      highlight.clear();
+
+      const registered: any = (CSS as any).highlights.get(highlight.name);
+      expect(registered.size).toBe(0);
+      expect((CSS as any).highlights.has(highlight.name)).toBe(true);
+    });
+
+    it('is safe to call before any range is set', () => {
+      const highlight = new CursorHighlight('red');
+      expect(() => highlight.clear()).not.toThrow();
+    });
+  });
+
+  describe('detach', () => {
+    it('unregisters the highlight and removes the stylesheet', () => {
+      const highlight = new CursorHighlight('red');
+      highlight.setRange(document.createRange(), document);
+
+      highlight.detach();
+
+      expect((CSS as any).highlights.has(highlight.name)).toBe(false);
+      expect((document as any).adoptedStyleSheets).toHaveLength(0);
+    });
+
+    it('is safe to call before attaching', () => {
+      const highlight = new CursorHighlight('red');
+      expect(() => highlight.detach()).not.toThrow();
+    });
+
+    it('only removes its own stylesheet', () => {
+      const first = new CursorHighlight('red');
+      const second = new CursorHighlight('blue');
+      first.setRange(document.createRange(), document);
+      second.setRange(document.createRange(), document);
+
+      first.detach();
+
+      const sheets: any[] = (document as any).adoptedStyleSheets;
+      expect(sheets).toHaveLength(1);
+      expect(sheets[0].cssText).toContain(second.name);
+    });
+  });
+
+  describe('warnIfUnsupported', () => {
+    it('does not warn when the API is supported', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation();
+      CursorHighlight.warnIfUnsupported();
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('warns exactly once when the API is unsupported', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation();
+      withoutGlobal('Highlight', () => {
+        CursorHighlight.warnIfUnsupported();
+        CursorHighlight.warnIfUnsupported();
+      });
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('CSS Custom Highlight API');
+      warn.mockRestore();
+    });
+  });
+
+  function withoutGlobal(name: string, callback: () => void): void {
+    const original = (globalThis as any)[name];
+    delete (globalThis as any)[name];
+    try {
+      callback();
+    } finally {
+      (globalThis as any)[name] = original;
+    }
+  }
+});

--- a/src/quill-cursors/cursor-highlight.spec.ts
+++ b/src/quill-cursors/cursor-highlight.spec.ts
@@ -54,22 +54,30 @@ describe('CursorHighlight', () => {
       expect(next.name).not.toBe(takenName);
       expect(next.name).toMatch(/^ql-cursor-highlight-\d+$/);
     });
+  });
 
-    it('allocates names when the registry is unavailable', () => {
-      const css = (globalThis as any).CSS;
-      (globalThis as any).CSS = {};
-      try {
-        const highlight = new CursorHighlight('red');
-        expect(highlight.name).toMatch(/^ql-cursor-highlight-\d+$/);
-      } finally {
-        (globalThis as any).CSS = css;
-      }
+  describe('priority', () => {
+    it('paints later-created highlights above earlier ones', () => {
+      const first = new CursorHighlight('red');
+      const second = new CursorHighlight('blue');
+      first.setRange(document.createRange(), document);
+      second.setRange(document.createRange(), document);
+
+      const earlier: any = (CSS as any).highlights.get(first.name);
+      const later: any = (CSS as any).highlights.get(second.name);
+      expect(later.priority).toBeGreaterThan(earlier.priority);
     });
   });
 
   describe('color sanitisation', () => {
+    let originalSupports: any;
+
+    beforeEach(() => {
+      originalSupports = (CSS as any).supports;
+    });
+
     afterEach(() => {
-      delete (CSS as any).supports;
+      (CSS as any).supports = originalSupports;
     });
 
     it('keeps colors that pass CSS.supports validation', () => {
@@ -95,24 +103,6 @@ describe('CursorHighlight', () => {
       );
     });
 
-    it('trusts the color when CSS.supports is unavailable', () => {
-      const highlight = new CursorHighlight('red');
-
-      highlight.setRange(document.createRange(), document);
-
-      expect((document as any).adoptedStyleSheets[0].cssText).toContain('red');
-    });
-
-    it('trusts the color when the CSS global is unavailable', () => {
-      let highlight: CursorHighlight;
-      withoutGlobal('CSS', () => {
-        highlight = new CursorHighlight('red');
-      });
-
-      highlight.setRange(document.createRange(), document);
-
-      expect((document as any).adoptedStyleSheets[0].cssText).toContain('red');
-    });
   });
 
   describe('setRange', () => {
@@ -209,16 +199,6 @@ describe('CursorHighlight', () => {
       expect((document as any).adoptedStyleSheets).toHaveLength(0);
     });
 
-    it('does nothing when the Highlight API is unsupported', () => {
-      const highlight = new CursorHighlight('red');
-      withoutGlobal('Highlight', () => {
-        highlight.setRange(document.createRange(), document);
-      });
-
-      expect((CSS as any).highlights.size).toBe(0);
-      expect((document as any).adoptedStyleSheets).toHaveLength(0);
-    });
-
     it('re-registers after detach when setRange is called again', () => {
       const highlight = new CursorHighlight('red');
       highlight.setRange(document.createRange(), document);
@@ -276,6 +256,14 @@ describe('CursorHighlight', () => {
       const sheets: any[] = (document as any).adoptedStyleSheets;
       expect(sheets).toHaveLength(1);
       expect(sheets[0].cssText).toContain(second.name);
+    });
+
+    it('tolerates a stylesheet already removed by external code', () => {
+      const highlight = new CursorHighlight('red');
+      highlight.setRange(document.createRange(), document);
+      (document as any).adoptedStyleSheets = [];
+
+      expect(() => highlight.detach()).not.toThrow();
     });
   });
 

--- a/src/quill-cursors/cursor-highlight.ts
+++ b/src/quill-cursors/cursor-highlight.ts
@@ -6,7 +6,10 @@ let nextHighlightNumber = 0;
 // globals exist.
 export default class CursorHighlight implements ICursorHighlight {
   public static readonly NAME_PREFIX = 'ql-cursor-highlight';
-  public static readonly SELECTION_ALPHA = '30%';
+  // Single source of truth for the fade lives in the stylesheet, which also
+  // uses it for the embed overlay opacity; the fallback covers setups that
+  // load the core bundle without the stylesheet.
+  public static readonly SELECTION_FADE = 'var(--ql-cursor-selection-fade, 0.3)';
 
   private static _hasWarnedUnsupported = false;
 
@@ -120,7 +123,8 @@ export default class CursorHighlight implements ICursorHighlight {
 
   private _buildSheet(): CSSStyleSheet {
     const sheet = new CSSStyleSheet();
-    const background = `color-mix(in srgb, ${ this._color } ${ CursorHighlight.SELECTION_ALPHA }, transparent)`;
+    const fade = `calc(${ CursorHighlight.SELECTION_FADE } * 100%)`;
+    const background = `color-mix(in srgb, ${ this._color } ${ fade }, transparent)`;
     sheet.replaceSync(`::highlight(${ this.name }) { background-color: ${ background }; }`);
     return sheet;
   }

--- a/src/quill-cursors/cursor-highlight.ts
+++ b/src/quill-cursors/cursor-highlight.ts
@@ -60,6 +60,9 @@ export default class CursorHighlight implements ICursorHighlight {
     this._color = CursorHighlight._safeColor(color);
     this._priority = CursorHighlight._nextNumber();
     this.name = `${ CursorHighlight.NAME_PREFIX }-${ this._priority }`;
+    // Register eagerly: this reserves the name in the page-global registry,
+    // so another module copy probing _nextNumber cannot take the same one.
+    this._register();
   }
 
   // The root is passed per call: the cursor element has no root until it is
@@ -77,20 +80,35 @@ export default class CursorHighlight implements ICursorHighlight {
     this._highlight.clear();
   }
 
+  // Hiding disables the stylesheet instead of dropping the ranges, so
+  // becoming visible again does not need a selection update.
+  public setVisible(visible: boolean): void {
+    if (!this._sheet) return;
+    this._sheet.disabled = !visible;
+  }
+
   public detach(): void {
     CSS.highlights.delete(this.name);
     this._highlight = null;
+    if (this._sheet) {
+      this._sheet.disabled = false;
+    }
     this._removeSheet();
+  }
+
+  private _register(): void {
+    this._highlight = new Highlight();
+    // Later-created cursors paint on top when selections overlap. Priority
+    // is fixed at creation: it cannot track document position, which
+    // changes with every edit.
+    this._highlight.priority = this._priority;
+    CSS.highlights.set(this.name, this._highlight);
   }
 
   private _attach(root: Node): void {
     if (!this._highlight) {
-      this._highlight = new Highlight();
-      // Later-created cursors paint on top when selections overlap. Priority
-      // is fixed at creation: it cannot track document position, which
-      // changes with every edit.
-      this._highlight.priority = this._priority;
-      CSS.highlights.set(this.name, this._highlight);
+      // Re-attach after detach()
+      this._register();
     }
 
     this._adoptSheetInto(this._styleRoot(root));

--- a/src/quill-cursors/cursor-highlight.ts
+++ b/src/quill-cursors/cursor-highlight.ts
@@ -1,0 +1,132 @@
+let nextHighlightNumber = 0;
+
+export default class CursorHighlight {
+  public static readonly NAME_PREFIX = 'ql-cursor-highlight';
+  public static readonly SELECTION_ALPHA = '30%';
+
+  private static _hasWarnedUnsupported = false;
+
+  public static isSupported(): boolean {
+    return typeof Highlight !== 'undefined' &&
+      typeof CSS !== 'undefined' &&
+      !!CSS.highlights;
+  }
+
+  public static warnIfUnsupported(): void {
+    if (CursorHighlight.isSupported() || CursorHighlight._hasWarnedUnsupported) return;
+    CursorHighlight._hasWarnedUnsupported = true;
+    console.warn(
+      'quill-cursors: This browser does not support the CSS Custom Highlight API. ' +
+      'Cursor carets and flags will work, but selection ranges will not be shown. ' +
+      'See https://github.com/reedsy/quill-cursors#browser-support',
+    );
+  }
+
+  // The color is interpolated into a stylesheet, where (unlike an inline
+  // style property assignment) a malicious string could escape the
+  // declaration and inject arbitrary document-level CSS. Validating it as a
+  // standalone color value prevents any breakout, while still allowing
+  // custom properties like var(--user-color).
+  private static _safeColor(color: string): string {
+    if (typeof CSS === 'undefined' || typeof CSS.supports !== 'function') return color;
+    return CSS.supports('background-color', color) ? color : 'transparent';
+  }
+
+  // Another copy of this module on the same page (e.g. duplicated bundles)
+  // shares the page-global registry but not this counter — skip taken names.
+  private static _nextName(): string {
+    let name = `${ CursorHighlight.NAME_PREFIX }-${ nextHighlightNumber++ }`;
+    while (typeof CSS !== 'undefined' && CSS.highlights && CSS.highlights.has(name)) {
+      name = `${ CursorHighlight.NAME_PREFIX }-${ nextHighlightNumber++ }`;
+    }
+    return name;
+  }
+
+  public readonly name: string;
+
+  private readonly _color: string;
+  private _highlight: Highlight | null = null;
+  private _sheet: CSSStyleSheet | null = null;
+  private _root: Document | ShadowRoot | null = null;
+
+  public constructor(color: string) {
+    this._color = CursorHighlight._safeColor(color);
+    this.name = CursorHighlight._nextName();
+  }
+
+  public setRange(range: Range | null, root: Node): void {
+    if (!CursorHighlight.isSupported()) return;
+
+    this._attach(root);
+    this._highlight.clear();
+    if (range) {
+      this._highlight.add(range);
+    }
+  }
+
+  public clear(): void {
+    if (!this._highlight) return;
+    this._highlight.clear();
+  }
+
+  public detach(): void {
+    if (this._highlight) {
+      CSS.highlights.delete(this.name);
+      this._highlight = null;
+    }
+
+    if (this._root) {
+      this._removeSheetFrom(this._root);
+      this._root = null;
+    }
+  }
+
+  private _attach(root: Node): void {
+    if (!this._highlight) {
+      this._highlight = new Highlight();
+      CSS.highlights.set(this.name, this._highlight);
+    }
+
+    this._adoptSheetInto(this._styleRoot(root));
+  }
+
+  private _adoptSheetInto(root: Document | ShadowRoot | null): void {
+    if (!root || root === this._root) return;
+
+    if (this._root) {
+      // The editor has moved to a different document or shadow root
+      this._removeSheetFrom(this._root);
+    }
+
+    if (!this._sheet) {
+      this._sheet = this._buildSheet();
+    }
+
+    root.adoptedStyleSheets = [...root.adoptedStyleSheets, this._sheet];
+    this._root = root;
+  }
+
+  private _removeSheetFrom(root: Document | ShadowRoot): void {
+    root.adoptedStyleSheets = root.adoptedStyleSheets
+      .filter((sheet: CSSStyleSheet) => sheet !== this._sheet);
+  }
+
+  private _buildSheet(): CSSStyleSheet {
+    const sheet = new CSSStyleSheet();
+    const background = `color-mix(in srgb, ${ this._color } ${ CursorHighlight.SELECTION_ALPHA }, transparent)`;
+    sheet.replaceSync(`::highlight(${ this.name }) { background-color: ${ background }; }`);
+    return sheet;
+  }
+
+  // Note: instanceof is realm-sensitive by design. A root from another realm
+  // (e.g. an editor inside an iframe while this library runs in the parent)
+  // is deliberately not matched: constructable stylesheets cannot be adopted
+  // across realms (the assignment throws), so foreign-realm roots degrade to
+  // carets-only rendering instead of crashing.
+  private _styleRoot(node: Node): Document | ShadowRoot | null {
+    if (node instanceof Document || node instanceof ShadowRoot) {
+      return node;
+    }
+    return null;
+  }
+}

--- a/src/quill-cursors/cursor-highlight.ts
+++ b/src/quill-cursors/cursor-highlight.ts
@@ -2,8 +2,8 @@ import ICursorHighlight from './i-cursor-highlight';
 
 let nextHighlightNumber = 0;
 
-// Assumes the Highlight API globals exist: only construct this class when
-// CursorHighlight.isSupported(), and use NoOpCursorHighlight otherwise.
+// Only constructed when isSupported(); methods assume the Highlight API
+// globals exist.
 export default class CursorHighlight implements ICursorHighlight {
   public static readonly NAME_PREFIX = 'ql-cursor-highlight';
   public static readonly SELECTION_ALPHA = '30%';
@@ -36,7 +36,7 @@ export default class CursorHighlight implements ICursorHighlight {
   }
 
   // Another copy of this module on the same page (e.g. duplicated bundles)
-  // shares the page-global registry but not this counter — skip taken numbers.
+  // shares the page-global registry but not this counter, so skip taken numbers.
   private static _nextNumber(): number {
     let number = nextHighlightNumber++;
     while (CSS.highlights.has(`${ CursorHighlight.NAME_PREFIX }-${ number }`)) {
@@ -59,9 +59,8 @@ export default class CursorHighlight implements ICursorHighlight {
     this.name = `${ CursorHighlight.NAME_PREFIX }-${ this._priority }`;
   }
 
-  // The root is passed per call rather than at construction because the
-  // cursor element is not attached to the DOM (and so has no root) until
-  // after Cursor.build().
+  // The root is passed per call: the cursor element has no root until it is
+  // attached to the DOM after build().
   public setRange(range: Range | null, root: Node): void {
     this._attach(root);
     this.clear();
@@ -84,10 +83,9 @@ export default class CursorHighlight implements ICursorHighlight {
   private _attach(root: Node): void {
     if (!this._highlight) {
       this._highlight = new Highlight();
-      // When selections overlap, later-created cursors paint on top of
-      // earlier ones, mirroring v4's DOM append order. The priority is fixed
-      // at creation: it cannot track document position, because positions
-      // change with every edit while a highlight's priority is static.
+      // Later-created cursors paint on top when selections overlap. Priority
+      // is fixed at creation: it cannot track document position, which
+      // changes with every edit.
       this._highlight.priority = this._priority;
       CSS.highlights.set(this.name, this._highlight);
     }
@@ -127,11 +125,10 @@ export default class CursorHighlight implements ICursorHighlight {
     return sheet;
   }
 
-  // Note: instanceof is realm-sensitive by design. A root from another realm
-  // (e.g. an editor inside an iframe while this library runs in the parent)
-  // is deliberately not matched: constructable stylesheets cannot be adopted
-  // across realms (the assignment throws), so foreign-realm roots degrade to
-  // carets-only rendering instead of crashing.
+  // instanceof is realm-sensitive by design: constructable stylesheets cannot
+  // be adopted across realms (the assignment throws), so a root from another
+  // realm (e.g. an iframe) degrades to carets-only rendering instead of
+  // crashing.
   private _styleRoot(node: Node): Document | ShadowRoot | null {
     if (node instanceof Document || node instanceof ShadowRoot) {
       return node;

--- a/src/quill-cursors/cursor-highlight.ts
+++ b/src/quill-cursors/cursor-highlight.ts
@@ -1,6 +1,10 @@
+import ICursorHighlight from './i-cursor-highlight';
+
 let nextHighlightNumber = 0;
 
-export default class CursorHighlight {
+// Assumes the Highlight API globals exist: only construct this class when
+// CursorHighlight.isSupported(), and use NoOpCursorHighlight otherwise.
+export default class CursorHighlight implements ICursorHighlight {
   public static readonly NAME_PREFIX = 'ql-cursor-highlight';
   public static readonly SELECTION_ALPHA = '30%';
 
@@ -28,37 +32,39 @@ export default class CursorHighlight {
   // standalone color value prevents any breakout, while still allowing
   // custom properties like var(--user-color).
   private static _safeColor(color: string): string {
-    if (typeof CSS === 'undefined' || typeof CSS.supports !== 'function') return color;
     return CSS.supports('background-color', color) ? color : 'transparent';
   }
 
   // Another copy of this module on the same page (e.g. duplicated bundles)
-  // shares the page-global registry but not this counter — skip taken names.
-  private static _nextName(): string {
-    let name = `${ CursorHighlight.NAME_PREFIX }-${ nextHighlightNumber++ }`;
-    while (typeof CSS !== 'undefined' && CSS.highlights && CSS.highlights.has(name)) {
-      name = `${ CursorHighlight.NAME_PREFIX }-${ nextHighlightNumber++ }`;
+  // shares the page-global registry but not this counter — skip taken numbers.
+  private static _nextNumber(): number {
+    let number = nextHighlightNumber++;
+    while (CSS.highlights.has(`${ CursorHighlight.NAME_PREFIX }-${ number }`)) {
+      number = nextHighlightNumber++;
     }
-    return name;
+    return number;
   }
 
   public readonly name: string;
 
   private readonly _color: string;
+  private readonly _priority: number;
   private _highlight: Highlight | null = null;
   private _sheet: CSSStyleSheet | null = null;
   private _root: Document | ShadowRoot | null = null;
 
   public constructor(color: string) {
     this._color = CursorHighlight._safeColor(color);
-    this.name = CursorHighlight._nextName();
+    this._priority = CursorHighlight._nextNumber();
+    this.name = `${ CursorHighlight.NAME_PREFIX }-${ this._priority }`;
   }
 
+  // The root is passed per call rather than at construction because the
+  // cursor element is not attached to the DOM (and so has no root) until
+  // after Cursor.build().
   public setRange(range: Range | null, root: Node): void {
-    if (!CursorHighlight.isSupported()) return;
-
     this._attach(root);
-    this._highlight.clear();
+    this.clear();
     if (range) {
       this._highlight.add(range);
     }
@@ -70,20 +76,19 @@ export default class CursorHighlight {
   }
 
   public detach(): void {
-    if (this._highlight) {
-      CSS.highlights.delete(this.name);
-      this._highlight = null;
-    }
-
-    if (this._root) {
-      this._removeSheetFrom(this._root);
-      this._root = null;
-    }
+    CSS.highlights.delete(this.name);
+    this._highlight = null;
+    this._removeSheet();
   }
 
   private _attach(root: Node): void {
     if (!this._highlight) {
       this._highlight = new Highlight();
+      // When selections overlap, later-created cursors paint on top of
+      // earlier ones, mirroring v4's DOM append order. The priority is fixed
+      // at creation: it cannot track document position, because positions
+      // change with every edit while a highlight's priority is static.
+      this._highlight.priority = this._priority;
       CSS.highlights.set(this.name, this._highlight);
     }
 
@@ -93,22 +98,26 @@ export default class CursorHighlight {
   private _adoptSheetInto(root: Document | ShadowRoot | null): void {
     if (!root || root === this._root) return;
 
-    if (this._root) {
-      // The editor has moved to a different document or shadow root
-      this._removeSheetFrom(this._root);
-    }
+    // The editor has moved to a different document or shadow root
+    this._removeSheet();
 
     if (!this._sheet) {
       this._sheet = this._buildSheet();
     }
 
-    root.adoptedStyleSheets = [...root.adoptedStyleSheets, this._sheet];
+    root.adoptedStyleSheets.push(this._sheet);
     this._root = root;
   }
 
-  private _removeSheetFrom(root: Document | ShadowRoot): void {
-    root.adoptedStyleSheets = root.adoptedStyleSheets
-      .filter((sheet: CSSStyleSheet) => sheet !== this._sheet);
+  private _removeSheet(): void {
+    if (!this._root) return;
+
+    const sheets = this._root.adoptedStyleSheets;
+    const index = sheets.indexOf(this._sheet);
+    if (index >= 0) {
+      sheets.splice(index, 1);
+    }
+    this._root = null;
   }
 
   private _buildSheet(): CSSStyleSheet {

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -8,7 +8,6 @@ describe('Cursor', () => {
 
   beforeEach(() => {
     template = `
-      <span class="ql-cursor-selections"></span>
       <span class="ql-cursor-caret-container">
         <span class="ql-cursor-caret"></span>
       </span>
@@ -40,7 +39,6 @@ describe('Cursor', () => {
     const element = new Cursor('abc', 'Jane Bloggs', 'red').build(options);
 
     expect(element).toContainHTML(`
-      <span class="ql-cursor-selections"></span>
       <span class="ql-cursor-caret-container">
         <span class="ql-cursor-caret" style="background-color: red;"></span>
       </span>
@@ -49,6 +47,15 @@ describe('Cursor', () => {
         <span class="ql-cursor-flag-flap"></span>
       </div>
     `);
+  });
+
+  it('tolerates legacy templates containing a selections element', () => {
+    options.template = `
+      <span class="ql-cursor-selections"></span>
+      ${ template }
+    `;
+    const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+    expect(() => cursor.build(options)).not.toThrow();
   });
 
   it('adds the ID to the element', () => {
@@ -80,6 +87,72 @@ describe('Cursor', () => {
 
     cursor.remove();
     expect(element).not.toBeInTheDocument();
+  });
+
+  it('exposes a unique highlight name', () => {
+    const first = new Cursor('abc', 'Jane Bloggs', 'red');
+    const second = new Cursor('def', 'Joe Bloggs', 'blue');
+
+    expect(first.highlightName).toMatch(/^ql-cursor-highlight-\d+$/);
+    expect(first.highlightName).not.toBe(second.highlightName);
+  });
+
+  describe('selection range highlight', () => {
+    let cursor: Cursor;
+    let element: HTMLElement;
+
+    beforeEach(() => {
+      cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+      element = cursor.build(options);
+      document.body.appendChild(element);
+    });
+
+    afterEach(() => {
+      if (element.parentNode) element.parentNode.removeChild(element);
+    });
+
+    it('registers the range in the highlight registry', () => {
+      const range = document.createRange();
+
+      cursor.setSelectionRange(range);
+
+      const registered: any = (CSS as any).highlights.get(cursor.highlightName);
+      expect(registered.has(range)).toBe(true);
+    });
+
+    it('adopts a stylesheet with the cursor color', () => {
+      cursor.setSelectionRange(document.createRange());
+
+      const sheets: any[] = (document as any).adoptedStyleSheets;
+      expect(sheets).toHaveLength(1);
+      expect(sheets[0].cssText).toContain('color-mix(in srgb, red 30%, transparent)');
+    });
+
+    it('empties the highlight when passed null', () => {
+      cursor.setSelectionRange(document.createRange());
+      cursor.setSelectionRange(null);
+
+      const registered: any = (CSS as any).highlights.get(cursor.highlightName);
+      expect(registered.size).toBe(0);
+    });
+
+    it('empties the highlight when the cursor is hidden', () => {
+      cursor.setSelectionRange(document.createRange());
+
+      cursor.hide();
+
+      const registered: any = (CSS as any).highlights.get(cursor.highlightName);
+      expect(registered.size).toBe(0);
+    });
+
+    it('unregisters the highlight when the cursor is removed', () => {
+      cursor.setSelectionRange(document.createRange());
+
+      cursor.remove();
+
+      expect((CSS as any).highlights.has(cursor.highlightName)).toBe(false);
+      expect((document as any).adoptedStyleSheets).toHaveLength(0);
+    });
   });
 
   it('updates the caret position', () => {
@@ -188,146 +261,6 @@ describe('Cursor', () => {
     expect(flag).toHaveClass(Cursor.NO_DELAY_CLASS);
     jest.advanceTimersByTime(options.hideSpeedMs);
     expect(flag).not.toHaveClass(Cursor.NO_DELAY_CLASS);
-  });
-
-  describe('with some selections', () => {
-    let cursor: Cursor;
-    let element: HTMLElement;
-    let container: any;
-    let selection1: any;
-    let selection2: any;
-
-    beforeEach(() => {
-      cursor = new Cursor('abc', 'Jane Bloggs', 'red');
-      element = cursor.build(options);
-
-      selection1 = {
-        top: 0,
-        left: 50,
-        width: 100,
-        height: 200,
-      };
-
-      selection2 = {
-        top: 1000,
-        left: 1050,
-        width: 200,
-        height: 300,
-      };
-
-      container = {
-        top: 0,
-        left: 0,
-        width: 2000,
-        height: 2000,
-      };
-
-      cursor.updateSelection([selection1, selection2], container);
-    });
-
-    it('adds selections', () => {
-      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
-
-      expect(selections.children.length).toBe(2);
-
-      expect(selections.children[0]).toHaveStyle('top: 0px');
-      expect(selections.children[0]).toHaveStyle('left: 50px');
-      expect(selections.children[0]).toHaveStyle('width: 100px');
-      expect(selections.children[0]).toHaveStyle('height: 200px');
-      expect(selections.children[0]).toHaveStyle('background-color: red');
-      expect(selections.children[0]).toHaveStyle('opacity: 0.3');
-
-      expect(selections.children[1]).toHaveStyle('top: 1000px');
-      expect(selections.children[1]).toHaveStyle('left: 1050px');
-      expect(selections.children[1]).toHaveStyle('width: 200px');
-      expect(selections.children[1]).toHaveStyle('height: 300px');
-      expect(selections.children[1]).toHaveStyle('background-color: red');
-      expect(selections.children[1]).toHaveStyle('opacity: 0.3');
-    });
-
-    it('clears the selection if nothing is passed in', () => {
-      cursor.updateSelection(null, container);
-      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
-      expect(selections.children).toHaveLength(0);
-    });
-
-    it('sorts the selections by DOM position', () => {
-      cursor.updateSelection([selection2, selection1], container);
-
-      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
-
-      expect(selections.children[0]).toHaveStyle('top: 0px');
-      expect(selections.children[0]).toHaveStyle('left: 50px');
-
-      expect(selections.children[1]).toHaveStyle('top: 1000px');
-      expect(selections.children[1]).toHaveStyle('left: 1050px');
-    });
-
-    it('sorts by left-to-right if the selection tops are the same', () => {
-      const selection3 = {
-        top: 0,
-        left: 150,
-        width: 100,
-        height: 200,
-      };
-
-      cursor.updateSelection([selection3, selection1], container);
-
-      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
-
-      expect(selections.children[0]).toHaveStyle('top: 0px');
-      expect(selections.children[0]).toHaveStyle('left: 50px');
-
-      expect(selections.children[1]).toHaveStyle('top: 0px');
-      expect(selections.children[1]).toHaveStyle('left: 150px');
-    });
-
-    it('deduplicates selections', () => {
-      cursor.updateSelection([selection1, selection1], container);
-
-      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
-
-      expect(selections.children).toHaveLength(1);
-
-      expect(selections.children[0]).toHaveStyle('top: 0px');
-      expect(selections.children[0]).toHaveStyle('left: 50px');
-    });
-
-    it('ignores selections with no width', () => {
-      const noWidthSelection = {
-        top: 0,
-        left: 0,
-        width: 0,
-        height: 100,
-      };
-
-      cursor.updateSelection([selection1, noWidthSelection], container);
-
-      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
-
-      expect(selections.children).toHaveLength(1);
-
-      expect(selections.children[0]).toHaveStyle('top: 0px');
-      expect(selections.children[0]).toHaveStyle('left: 50px');
-    });
-
-    it('ignores selections with no height', () => {
-      const noHeightSelection = {
-        top: 0,
-        left: 0,
-        width: 100,
-        height: 0,
-      };
-
-      cursor.updateSelection([selection1, noHeightSelection], container);
-
-      const selections = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0];
-
-      expect(selections.children).toHaveLength(1);
-
-      expect(selections.children[0]).toHaveStyle('top: 0px');
-      expect(selections.children[0]).toHaveStyle('left: 50px');
-    });
   });
 
   describe('mouse move handlers', () => {

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -204,13 +204,19 @@ describe('Cursor', () => {
       expect(registered.size).toBe(0);
     });
 
-    it('empties the highlight when the cursor is hidden', () => {
-      cursor.setSelectionRange(document.createRange());
+    it('hides the highlight without losing the selection', () => {
+      const range = document.createRange();
+      cursor.setSelectionRange(range);
 
       cursor.hide();
 
-      const registered: any = (CSS as any).highlights.get(cursor.highlightName);
-      expect(registered.size).toBe(0);
+      const sheets: any[] = (document as any).adoptedStyleSheets;
+      expect(sheets[0].disabled).toBe(true);
+      expect((CSS as any).highlights.get(cursor.highlightName).has(range)).toBe(true);
+
+      cursor.show();
+
+      expect(sheets[0].disabled).toBe(false);
     });
 
     it('unregisters the highlight when the cursor is removed', () => {

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -193,7 +193,7 @@ describe('Cursor', () => {
 
       const sheets: any[] = (document as any).adoptedStyleSheets;
       expect(sheets).toHaveLength(1);
-      expect(sheets[0].cssText).toContain('color-mix(in srgb, red 30%, transparent)');
+      expect(sheets[0].cssText).toContain('color-mix(in srgb, red calc(var(--ql-cursor-selection-fade, 0.3) * 100%)');
     });
 
     it('empties the highlight when passed null', () => {

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -146,7 +146,6 @@ describe('Cursor', () => {
       expect(blocks[0]).toHaveStyle('width: 100px');
       expect(blocks[0]).toHaveStyle('height: 50px');
       expect(blocks[0]).toHaveStyle('background-color: red');
-      expect(blocks[0]).toHaveStyle('opacity: 0.3');
     });
 
     it('clears previous blocks on update', () => {

--- a/src/quill-cursors/cursor.spec.ts
+++ b/src/quill-cursors/cursor.spec.ts
@@ -8,6 +8,7 @@ describe('Cursor', () => {
 
   beforeEach(() => {
     template = `
+      <span class="ql-cursor-selections"></span>
       <span class="ql-cursor-caret-container">
         <span class="ql-cursor-caret"></span>
       </span>
@@ -39,6 +40,7 @@ describe('Cursor', () => {
     const element = new Cursor('abc', 'Jane Bloggs', 'red').build(options);
 
     expect(element).toContainHTML(`
+      <span class="ql-cursor-selections"></span>
       <span class="ql-cursor-caret-container">
         <span class="ql-cursor-caret" style="background-color: red;"></span>
       </span>
@@ -49,13 +51,21 @@ describe('Cursor', () => {
     `);
   });
 
-  it('tolerates legacy templates containing a selections element', () => {
+  it('tolerates templates without a selections element', () => {
     options.template = `
-      <span class="ql-cursor-selections"></span>
-      ${ template }
+      <span class="ql-cursor-caret-container">
+        <span class="ql-cursor-caret"></span>
+      </span>
+      <div class="ql-cursor-flag">
+        <small class="ql-cursor-name"></small>
+      </div>
     `;
     const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
-    expect(() => cursor.build(options)).not.toThrow();
+    cursor.build(options);
+
+    const rectangle: any = {top: 10, left: 10, width: 100, height: 20};
+    const container: any = {top: 0, left: 0, width: 500, height: 500};
+    expect(() => cursor.updateEmbedSelections([rectangle], container)).not.toThrow();
   });
 
   it('adds the ID to the element', () => {
@@ -95,6 +105,65 @@ describe('Cursor', () => {
 
     expect(first.highlightName).toMatch(/^ql-cursor-highlight-\d+$/);
     expect(first.highlightName).not.toBe(second.highlightName);
+  });
+
+  it('uses a no-op highlight when the Highlight API is unsupported', () => {
+    const highlight = (globalThis as any).Highlight;
+    delete (globalThis as any).Highlight;
+    try {
+      const cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+      cursor.build(options);
+
+      expect(cursor.highlightName).toBe('');
+      expect(() => cursor.setSelectionRange(document.createRange())).not.toThrow();
+      expect((CSS as any).highlights.size).toBe(0);
+    } finally {
+      (globalThis as any).Highlight = highlight;
+    }
+  });
+
+  describe('embed selections', () => {
+    let cursor: Cursor;
+    let element: HTMLElement;
+    let container: any;
+
+    beforeEach(() => {
+      cursor = new Cursor('abc', 'Jane Bloggs', 'red');
+      element = cursor.build(options);
+      container = {top: 5, left: 5, width: 2000, height: 2000};
+    });
+
+    it('draws a tinted block over each rectangle', () => {
+      cursor.updateEmbedSelections([
+        {top: 10, left: 20, width: 100, height: 50},
+        {top: 100, left: 20, width: 200, height: 80},
+      ] as any, container);
+
+      const blocks = element.getElementsByClassName(Cursor.SELECTION_BLOCK_CLASS);
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0]).toHaveStyle('top: 5px');
+      expect(blocks[0]).toHaveStyle('left: 15px');
+      expect(blocks[0]).toHaveStyle('width: 100px');
+      expect(blocks[0]).toHaveStyle('height: 50px');
+      expect(blocks[0]).toHaveStyle('background-color: red');
+      expect(blocks[0]).toHaveStyle('opacity: 0.3');
+    });
+
+    it('clears previous blocks on update', () => {
+      cursor.updateEmbedSelections([{top: 10, left: 20, width: 100, height: 50}] as any, container);
+      cursor.updateEmbedSelections([], container);
+
+      expect(element.getElementsByClassName(Cursor.SELECTION_BLOCK_CLASS)).toHaveLength(0);
+    });
+
+    it('skips rectangles without an area', () => {
+      cursor.updateEmbedSelections([
+        {top: 10, left: 20, width: 0, height: 50},
+        {top: 10, left: 20, width: 100, height: 0},
+      ] as any, container);
+
+      expect(element.getElementsByClassName(Cursor.SELECTION_BLOCK_CLASS)).toHaveLength(0);
+    });
   });
 
   describe('selection range highlight', () => {

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -84,10 +84,8 @@ export default class Cursor {
     this._el.classList.remove(Cursor.HIDDEN_CLASS);
   }
 
-  // Also clears the highlight: it lives in the global registry, not in this
-  // cursor's hidden DOM container. No restore needed on show() — full updates
-  // always follow show() with a selection update, and caret-only updates
-  // (scroll/resize) intentionally leave the highlight untouched.
+  // The highlight lives in the global registry, not in this hidden container,
+  // so it needs clearing; the next selection update after show() repaints it.
   public hide(): void {
     this._el.classList.add(Cursor.HIDDEN_CLASS);
     this._highlight.clear();
@@ -135,11 +133,8 @@ export default class Cursor {
     this._highlight.setRange(range, this._el.getRootNode());
   }
 
-  // Text is tinted via the Highlight API (setSelectionRange), but custom
-  // highlights do not paint over embeds. Embeds included in the selection —
-  // inline (e.g. images) or block (e.g. videos) — get a tinted overlay
-  // rectangle instead, like the ones v4 drew for the whole selection and the
-  // way native selection paints replaced elements.
+  // Custom highlights cannot paint over embeds, so embeds in the selection
+  // (inline like images, block like videos) get a tinted overlay instead.
   public updateEmbedSelections(rectangles: ClientRect[], container: ClientRect): void {
     if (!this._selectionEl) return; // custom template without a selections element
 

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -136,10 +136,10 @@ export default class Cursor {
   }
 
   // Text is tinted via the Highlight API (setSelectionRange), but custom
-  // highlights do not paint over embeds. Block embeds included in the
-  // selection get a tinted overlay rectangle instead, like the ones v4 drew
-  // for the whole selection. Inline embeds are deliberately skipped, matching
-  // native selection painting.
+  // highlights do not paint over embeds. Embeds included in the selection —
+  // inline (e.g. images) or block (e.g. videos) — get a tinted overlay
+  // rectangle instead, like the ones v4 drew for the whole selection and the
+  // way native selection paints replaced elements.
   public updateEmbedSelections(rectangles: ClientRect[], container: ClientRect): void {
     if (!this._selectionEl) return; // custom template without a selections element
 

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -82,13 +82,14 @@ export default class Cursor {
 
   public show(): void {
     this._el.classList.remove(Cursor.HIDDEN_CLASS);
+    this._highlight.setVisible(true);
   }
 
   // The highlight lives in the global registry, not in this hidden container,
-  // so it needs clearing; the next selection update after show() repaints it.
+  // so it is toggled through its stylesheet instead of the hidden class.
   public hide(): void {
     this._el.classList.add(Cursor.HIDDEN_CLASS);
-    this._highlight.clear();
+    this._highlight.setVisible(false);
   }
 
   public remove(): void {

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -169,7 +169,6 @@ export default class Cursor {
     element.style.width = `${rectangle.width}px`;
     element.style.height = `${rectangle.height}px`;
     element.style.backgroundColor = this.color;
-    element.style.opacity = '0.3';
 
     return element;
   }

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -1,11 +1,16 @@
 import IQuillCursorsOptions from './i-quill-cursors-options';
 import IQuillRange from './i-range';
 import {ICoordinates} from './i-coordinates';
+import ICursorHighlight from './i-cursor-highlight';
 import CursorHighlight from './cursor-highlight';
+import NoOpCursorHighlight from './no-op-cursor-highlight';
 
 export default class Cursor {
   public static readonly CONTAINER_ELEMENT_TAG = 'SPAN';
+  public static readonly SELECTION_ELEMENT_TAG = 'SPAN';
   public static readonly CURSOR_CLASS = 'ql-cursor';
+  public static readonly SELECTION_CLASS = 'ql-cursor-selections';
+  public static readonly SELECTION_BLOCK_CLASS = 'ql-cursor-selection-block';
   public static readonly CARET_CLASS = 'ql-cursor-caret';
   public static readonly CARET_CONTAINER_CLASS = 'ql-cursor-caret-container';
   public static readonly CONTAINER_HOVER_CLASS = 'hover';
@@ -23,18 +28,21 @@ export default class Cursor {
   public readonly highlightName: string;
 
   private _el: HTMLElement;
+  private _selectionEl: HTMLElement;
   private _caretEl: HTMLElement;
   private _flagEl: HTMLElement;
   private _hideDelay: string;
   private _hideSpeedMs: number;
   private _positionFlag: (flag: HTMLElement, caretRectangle: ClientRect, container: ClientRect) => void;
-  private readonly _highlight: CursorHighlight;
+  private readonly _highlight: ICursorHighlight;
 
   public constructor(id: string, name: string, color: string) {
     this.id = id;
     this.name = name;
     this.color = color;
-    this._highlight = new CursorHighlight(color);
+    this._highlight = CursorHighlight.isSupported() ?
+      new CursorHighlight(color) :
+      new NoOpCursorHighlight();
     this.highlightName = this._highlight.name;
     this.toggleNearCursor = this.toggleNearCursor.bind(this);
     this._toggleOpenedCursor = this._toggleOpenedCursor.bind(this);
@@ -46,6 +54,7 @@ export default class Cursor {
     element.classList.add(Cursor.CURSOR_CLASS);
     element.id = `ql-cursor-${ this.id }`;
     element.innerHTML = options.template;
+    const selectionElement = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0] as HTMLElement;
     const caretContainerElement = element.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0] as HTMLElement;
     const caretElement = caretContainerElement.getElementsByClassName(Cursor.CARET_CLASS)[0] as HTMLElement;
     const flagElement = element.getElementsByClassName(Cursor.FLAG_CLASS)[0] as HTMLElement;
@@ -62,6 +71,7 @@ export default class Cursor {
     flagElement.style.transitionDuration = `${this._hideSpeedMs}ms`;
 
     this._el = element;
+    this._selectionEl = selectionElement;
     this._caretEl = caretContainerElement;
     this._flagEl = flagElement;
 
@@ -125,6 +135,22 @@ export default class Cursor {
     this._highlight.setRange(range, this._el.getRootNode());
   }
 
+  // Text is tinted via the Highlight API (setSelectionRange), but custom
+  // highlights do not paint over embeds. Block embeds included in the
+  // selection get a tinted overlay rectangle instead, like the ones v4 drew
+  // for the whole selection. Inline embeds are deliberately skipped, matching
+  // native selection painting.
+  public updateEmbedSelections(rectangles: ClientRect[], container: ClientRect): void {
+    if (!this._selectionEl) return; // custom template without a selections element
+
+    this._selectionEl.innerHTML = '';
+    rectangles
+      .filter((rectangle: ClientRect) => rectangle.width && rectangle.height)
+      .forEach((rectangle: ClientRect) => {
+        this._selectionEl.appendChild(this._selectionBlock(rectangle, container));
+      });
+  }
+
   private _setHoverState(): void {
     document.addEventListener('mousemove', this._toggleOpenedCursor, {passive: true});
   }
@@ -137,6 +163,20 @@ export default class Cursor {
 
   private _getCoordinates(): ICoordinates {
     return this._caretEl.getBoundingClientRect();
+  }
+
+  private _selectionBlock(rectangle: ClientRect, container: ClientRect): HTMLElement {
+    const element = document.createElement(Cursor.SELECTION_ELEMENT_TAG);
+
+    element.classList.add(Cursor.SELECTION_BLOCK_CLASS);
+    element.style.top = `${rectangle.top - container.top}px`;
+    element.style.left = `${rectangle.left - container.left}px`;
+    element.style.width = `${rectangle.width}px`;
+    element.style.height = `${rectangle.height}px`;
+    element.style.backgroundColor = this.color;
+    element.style.opacity = '0.3';
+
+    return element;
   }
 
   private _updateCaretFlag(caretRectangle: ClientRect, container: ClientRect): void {

--- a/src/quill-cursors/cursor.ts
+++ b/src/quill-cursors/cursor.ts
@@ -1,13 +1,11 @@
 import IQuillCursorsOptions from './i-quill-cursors-options';
 import IQuillRange from './i-range';
 import {ICoordinates} from './i-coordinates';
+import CursorHighlight from './cursor-highlight';
 
 export default class Cursor {
   public static readonly CONTAINER_ELEMENT_TAG = 'SPAN';
-  public static readonly SELECTION_ELEMENT_TAG = 'SPAN';
   public static readonly CURSOR_CLASS = 'ql-cursor';
-  public static readonly SELECTION_CLASS = 'ql-cursor-selections';
-  public static readonly SELECTION_BLOCK_CLASS = 'ql-cursor-selection-block';
   public static readonly CARET_CLASS = 'ql-cursor-caret';
   public static readonly CARET_CONTAINER_CLASS = 'ql-cursor-caret-container';
   public static readonly CONTAINER_HOVER_CLASS = 'hover';
@@ -22,19 +20,22 @@ export default class Cursor {
   public readonly name: string;
   public readonly color: string;
   public range: IQuillRange;
+  public readonly highlightName: string;
 
   private _el: HTMLElement;
-  private _selectionEl: HTMLElement;
   private _caretEl: HTMLElement;
   private _flagEl: HTMLElement;
   private _hideDelay: string;
   private _hideSpeedMs: number;
   private _positionFlag: (flag: HTMLElement, caretRectangle: ClientRect, container: ClientRect) => void;
+  private readonly _highlight: CursorHighlight;
 
   public constructor(id: string, name: string, color: string) {
     this.id = id;
     this.name = name;
     this.color = color;
+    this._highlight = new CursorHighlight(color);
+    this.highlightName = this._highlight.name;
     this.toggleNearCursor = this.toggleNearCursor.bind(this);
     this._toggleOpenedCursor = this._toggleOpenedCursor.bind(this);
     this._setHoverState = this._setHoverState.bind(this);
@@ -45,7 +46,6 @@ export default class Cursor {
     element.classList.add(Cursor.CURSOR_CLASS);
     element.id = `ql-cursor-${ this.id }`;
     element.innerHTML = options.template;
-    const selectionElement = element.getElementsByClassName(Cursor.SELECTION_CLASS)[0] as HTMLElement;
     const caretContainerElement = element.getElementsByClassName(Cursor.CARET_CONTAINER_CLASS)[0] as HTMLElement;
     const caretElement = caretContainerElement.getElementsByClassName(Cursor.CARET_CLASS)[0] as HTMLElement;
     const flagElement = element.getElementsByClassName(Cursor.FLAG_CLASS)[0] as HTMLElement;
@@ -62,7 +62,6 @@ export default class Cursor {
     flagElement.style.transitionDuration = `${this._hideSpeedMs}ms`;
 
     this._el = element;
-    this._selectionEl = selectionElement;
     this._caretEl = caretContainerElement;
     this._flagEl = flagElement;
 
@@ -75,11 +74,17 @@ export default class Cursor {
     this._el.classList.remove(Cursor.HIDDEN_CLASS);
   }
 
+  // Also clears the highlight: it lives in the global registry, not in this
+  // cursor's hidden DOM container. No restore needed on show() — full updates
+  // always follow show() with a selection update, and caret-only updates
+  // (scroll/resize) intentionally leave the highlight untouched.
   public hide(): void {
     this._el.classList.add(Cursor.HIDDEN_CLASS);
+    this._highlight.clear();
   }
 
   public remove(): void {
+    this._highlight.detach();
     this._el.parentNode.removeChild(this._el);
   }
 
@@ -116,13 +121,8 @@ export default class Cursor {
     }
   }
 
-  public updateSelection(selections: ClientRect[], container: ClientRect): void {
-    this._clearSelection();
-    selections = selections || [];
-    selections = Array.from(selections);
-    selections = this._sanitize(selections);
-    selections = this._sortByDomPosition(selections);
-    selections.forEach((selection: ClientRect) => this._addSelection(selection, container));
+  public setSelectionRange(range: Range | null): void {
+    this._highlight.setRange(range, this._el.getRootNode());
   }
 
   private _setHoverState(): void {
@@ -151,65 +151,5 @@ export default class Cursor {
     this._flagEl.style.top = `${caretRectangle.top}px`;
     // Chrome has an issue when doing translate3D with non integer width, this ceil is to overcome it.
     this._flagEl.style.width = `${Math.ceil(flagRect.width)}px`;
-  }
-
-  private _clearSelection(): void {
-    this._selectionEl.innerHTML = '';
-  }
-
-  private _addSelection(selection: ClientRect, container: ClientRect): void {
-    const selectionBlock = this._selectionBlock(selection, container);
-    this._selectionEl.appendChild(selectionBlock);
-  }
-
-  private _selectionBlock(selection: ClientRect, container: ClientRect): HTMLElement {
-    const element = document.createElement(Cursor.SELECTION_ELEMENT_TAG);
-
-    element.classList.add(Cursor.SELECTION_BLOCK_CLASS);
-    element.style.top = `${selection.top - container.top}px`;
-    element.style.left = `${selection.left - container.left}px`;
-    element.style.width = `${selection.width}px`;
-    element.style.height = `${selection.height}px`;
-    element.style.backgroundColor = this.color;
-    element.style.opacity = '0.3';
-
-    return element;
-  }
-
-  private _sortByDomPosition(selections: ClientRect[]): ClientRect[] {
-    return selections.sort((a, b) => {
-      if (a.top === b.top) {
-        return a.left - b.left;
-      }
-
-      return a.top - b.top;
-    });
-  }
-
-  private _sanitize(selections: ClientRect[]): ClientRect[] {
-    const serializedSelections = new Set();
-
-    return selections.filter((selection: ClientRect) => {
-      if (!selection.width || !selection.height) {
-        return false;
-      }
-
-      const serialized = this._serialize(selection);
-      if (serializedSelections.has(serialized)) {
-        return false;
-      }
-
-      serializedSelections.add(serialized);
-      return true;
-    });
-  }
-
-  private _serialize(selection: ClientRect): string {
-    return [
-      `top:${ selection.top }`,
-      `right:${ selection.right }`,
-      `bottom:${ selection.bottom }`,
-      `left:${ selection.left }`,
-    ].join(';');
   }
 }

--- a/src/quill-cursors/i-cursor-highlight.ts
+++ b/src/quill-cursors/i-cursor-highlight.ts
@@ -1,0 +1,6 @@
+export default interface ICursorHighlight {
+  readonly name: string;
+  setRange(range: Range | null, root: Node): void;
+  clear(): void;
+  detach(): void;
+}

--- a/src/quill-cursors/i-cursor-highlight.ts
+++ b/src/quill-cursors/i-cursor-highlight.ts
@@ -2,5 +2,6 @@ export default interface ICursorHighlight {
   readonly name: string;
   setRange(range: Range | null, root: Node): void;
   clear(): void;
+  setVisible(visible: boolean): void;
   detach(): void;
 }

--- a/src/quill-cursors/no-op-cursor-highlight.spec.ts
+++ b/src/quill-cursors/no-op-cursor-highlight.spec.ts
@@ -1,0 +1,16 @@
+import ICursorHighlight from './i-cursor-highlight';
+import NoOpCursorHighlight from './no-op-cursor-highlight';
+
+describe('NoOpCursorHighlight', () => {
+  it('does nothing and touches no globals', () => {
+    const highlight: ICursorHighlight = new NoOpCursorHighlight();
+
+    highlight.setRange(document.createRange(), document);
+    highlight.clear();
+    highlight.detach();
+
+    expect(highlight.name).toBe('');
+    expect((CSS as any).highlights.size).toBe(0);
+    expect((document as any).adoptedStyleSheets).toHaveLength(0);
+  });
+});

--- a/src/quill-cursors/no-op-cursor-highlight.spec.ts
+++ b/src/quill-cursors/no-op-cursor-highlight.spec.ts
@@ -7,6 +7,7 @@ describe('NoOpCursorHighlight', () => {
 
     highlight.setRange(document.createRange(), document);
     highlight.clear();
+    highlight.setVisible(false);
     highlight.detach();
 
     expect(highlight.name).toBe('');

--- a/src/quill-cursors/no-op-cursor-highlight.ts
+++ b/src/quill-cursors/no-op-cursor-highlight.ts
@@ -1,8 +1,7 @@
 import ICursorHighlight from './i-cursor-highlight';
 
-// Used in place of CursorHighlight when the browser does not support the
-// CSS Custom Highlight API: carets, flags and embed overlays still render
-// (they are plain DOM elements), and text selections are skipped entirely.
+// Stands in for CursorHighlight when the CSS Custom Highlight API is
+// unsupported: text selections are skipped entirely.
 export default class NoOpCursorHighlight implements ICursorHighlight {
   public readonly name = '';
 

--- a/src/quill-cursors/no-op-cursor-highlight.ts
+++ b/src/quill-cursors/no-op-cursor-highlight.ts
@@ -1,0 +1,20 @@
+import ICursorHighlight from './i-cursor-highlight';
+
+// Used in place of CursorHighlight when the browser does not support the
+// CSS Custom Highlight API: carets, flags and embed overlays still render
+// (they are plain DOM elements), and text selections are skipped entirely.
+export default class NoOpCursorHighlight implements ICursorHighlight {
+  public readonly name = '';
+
+  public setRange(): void {
+    // no-op
+  }
+
+  public clear(): void {
+    // no-op
+  }
+
+  public detach(): void {
+    // no-op
+  }
+}

--- a/src/quill-cursors/no-op-cursor-highlight.ts
+++ b/src/quill-cursors/no-op-cursor-highlight.ts
@@ -13,6 +13,10 @@ export default class NoOpCursorHighlight implements ICursorHighlight {
     // no-op
   }
 
+  public setVisible(): void {
+    // no-op
+  }
+
   public detach(): void {
     // no-op
   }

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -1,18 +1,14 @@
 import QuillCursors from './quill-cursors';
 import Cursor from './cursor';
+import CursorHighlight from './cursor-highlight';
 import '@testing-library/jest-dom/extend-expect';
-import ResizeObserver from 'resize-observer-polyfill';
 
 const mockObserver = jest.fn();
 const mockDisconnect = jest.fn();
-jest.mock('resize-observer-polyfill', () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      observe: mockObserver,
-      disconnect: mockDisconnect,
-    };
-  });
-});
+const ResizeObserverMock = jest.fn().mockImplementation(() => ({
+  observe: mockObserver,
+  disconnect: mockDisconnect,
+}));
 
 describe('QuillCursors', () => {
   let quill: any;
@@ -50,7 +46,6 @@ describe('QuillCursors', () => {
       getLeaf: (): any => {},
       getLength: (): number => 0,
       getSelection: (): void => {},
-      getLines: (): any[] => [],
       on: (): void => {},
       off: (): void => {},
     };
@@ -65,7 +60,8 @@ describe('QuillCursors', () => {
 
     quill.constructor.find.mockReturnValue(quill);
 
-    (ResizeObserver as any).mockClear();
+    (globalThis as any).ResizeObserver = ResizeObserverMock;
+    ResizeObserverMock.mockClear();
     mockObserver.mockClear();
     mockDisconnect.mockClear();
   });
@@ -77,16 +73,46 @@ describe('QuillCursors', () => {
       expect(quill.addContainer).toHaveBeenCalledTimes(1);
     });
 
-    it('registers a scroll listener', () => {
+    it('repositions only carets on scroll', () => {
       const editor = quill.root;
       jest.spyOn(editor, 'addEventListener');
       const cursors = new QuillCursors(quill);
       expect(editor.addEventListener).toHaveBeenCalledWith('scroll', expect.anything(), {passive: true});
 
-      jest.spyOn(cursors, 'update');
-      const scroll = new Event('scroll');
-      editor.dispatchEvent(scroll);
-      expect(cursors.update).toHaveBeenCalled();
+      const cursor = cursors.createCursor('abc', 'Jane Bloggs', 'red');
+      cursor.range = {index: 0, length: 1};
+      jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: document.createTextNode('foo')}, 0]);
+      jest.spyOn(quill, 'getBounds').mockReturnValue({top: 0, left: 0, width: 0, height: 0});
+      jest.spyOn(cursor, 'updateCaret');
+      jest.spyOn(cursor, 'setSelectionRange');
+
+      editor.dispatchEvent(new Event('scroll'));
+
+      expect(cursor.updateCaret).toHaveBeenCalled();
+      expect(cursor.setSelectionRange).not.toHaveBeenCalled();
+    });
+
+    it('updates selections on update()', () => {
+      const cursors = new QuillCursors(quill);
+      const cursor = cursors.createCursor('xyz', 'Joe Bloggs', 'blue');
+      cursor.range = {index: 0, length: 1};
+      jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: document.createTextNode('foo')}, 0]);
+      jest.spyOn(quill, 'getBounds').mockReturnValue({top: 0, left: 0, width: 0, height: 0});
+      jest.spyOn(cursor, 'setSelectionRange');
+
+      cursors.update();
+
+      expect(cursor.setSelectionRange).toHaveBeenCalled();
+    });
+
+    it('warns when the Highlight API is unsupported', () => {
+      const warn = jest.spyOn(CursorHighlight, 'warnIfUnsupported').mockImplementation();
+      try {
+        new QuillCursors(quill);
+        expect(warn).toHaveBeenCalledTimes(1);
+      } finally {
+        warn.mockRestore();
+      }
     });
   });
 
@@ -105,16 +131,22 @@ describe('QuillCursors', () => {
       expect(mockObserver).toHaveBeenCalledTimes(1);
       expect(mockObserver).toHaveBeenCalledWith(editor);
 
-      expect(ResizeObserver).toHaveBeenCalledTimes(1);
-      const callback = (ResizeObserver as any).mock.calls[0][0];
-      jest.spyOn(cursors, 'update');
+      expect(ResizeObserverMock).toHaveBeenCalledTimes(1);
+      const callback = ResizeObserverMock.mock.calls[0][0];
+      const cursor = cursors.cursors()[0];
+      cursor.range = {index: 0, length: 1};
+      jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: document.createTextNode('foo')}, 0]);
+      jest.spyOn(quill, 'getBounds').mockReturnValue({top: 0, left: 0, width: 0, height: 0});
+      jest.spyOn(cursor, 'updateCaret');
+      jest.spyOn(cursor, 'setSelectionRange');
       callback([{target: {isConnected: true}}]);
-      expect(cursors.update).toHaveBeenCalledTimes(1);
+      expect(cursor.updateCaret).toHaveBeenCalled();
+      expect(cursor.setSelectionRange).not.toHaveBeenCalled();
     });
 
     it('disconnects and reconnects the observer if the cursors are updated again', () => {
       mockObserver.mockReset();
-      const callback = (ResizeObserver as any).mock.calls[0][0];
+      const callback = ResizeObserverMock.mock.calls[0][0];
       callback([{target: {isConnected: false}}]);
       expect(mockDisconnect).toHaveBeenCalledTimes(1);
 
@@ -123,7 +155,7 @@ describe('QuillCursors', () => {
     });
 
     it('does not disconnect if the node is still connected', () => {
-      const callback = (ResizeObserver as any).mock.calls[0][0];
+      const callback = ResizeObserverMock.mock.calls[0][0];
       callback([{target: {isConnected: true}}]);
       expect(mockDisconnect).toHaveBeenCalledTimes(0);
     });
@@ -375,17 +407,12 @@ describe('QuillCursors', () => {
       });
 
       mockRange = {
+        collapsed: false,
         setStart: () => { },
         setStartBefore: () => { },
         setEnd: () => { },
         setEndAfter: () => { },
-        getClientRects: () => {
-          const rectangles: any[] = [];
-          return rectangles;
-        },
         getBoundingClientRect: () => ({}),
-        cloneRange: () => mockRange,
-        selectNode: () => { },
       };
       document.createRange = () => mockRange;
     });
@@ -441,20 +468,7 @@ describe('QuillCursors', () => {
       expect(quill.getLeaf).toHaveBeenCalledWith(9);
     });
 
-    it('selects a block embed element', () => {
-      const img = document.createElement('img');
-      jest.spyOn(quill, 'getLeaf').mockReturnValue(createLeaf());
-      jest.spyOn(quill, 'getLines').mockReturnValue([
-        {domNode: img},
-      ]);
-      jest.spyOn(mockRange, 'selectNode');
-
-      cursors.moveCursor(cursor.id, {index: 0, length: 0});
-
-      expect(mockRange.selectNode).toHaveBeenCalledWith(img);
-    });
-
-    it('sets the range for a single line on the start and end leafs', () => {
+    it('sets the highlight range on the start and end leaves', () => {
       const startIndex = 0;
       const endIndex = 2;
       const startLeaf = createLeaf();
@@ -469,80 +483,47 @@ describe('QuillCursors', () => {
             return null;
         }
       }) as any);
-      jest.spyOn(quill, 'getLines').mockReturnValue([{
-        children: [],
-      }]);
       jest.spyOn(mockRange, 'setStart');
       jest.spyOn(mockRange, 'setEnd');
 
-      const range = {index: startIndex, length: endIndex - startIndex};
-
-      cursors.moveCursor(cursor.id, range);
+      cursors.moveCursor(cursor.id, {index: startIndex, length: endIndex - startIndex});
 
       expect(mockRange.setStart).toHaveBeenCalledWith(startLeaf[0].domNode, startLeaf[1]);
       expect(mockRange.setEnd).toHaveBeenCalledWith(endLeaf[0].domNode, endLeaf[1]);
+
+      const registered: any = (CSS as any).highlights.get(cursor.highlightName);
+      expect(registered.has(mockRange)).toBe(true);
     });
 
-    it('sets the range for multiple lines based on the line path', () => {
-      const startIndex = 0;
-      const endIndex = 2;
-      const startLeaf = createLeaf();
-      const endLeaf = createLeaf();
-      jest.spyOn(quill, 'getLeaf').mockImplementation(((index: number) => {
-        switch (index) {
-          case startIndex:
-            return startLeaf;
-          case endIndex:
-            return endLeaf;
-          default:
-            return null;
-        }
-      }) as any);
-      const line1Leaf = createLeaf();
-      const line2Leaf = createLeaf();
-      jest.spyOn(quill, 'getLines').mockReturnValue([
-        {
-          children: [],
-          path: (): any[] => [line1Leaf],
-          length: (): number => 1,
-        },
-        {
-          children: [],
-          path: (): any[] => [line2Leaf],
-          length: (): number => 1,
-        },
-      ]);
-      jest.spyOn(mockRange, 'setStart');
-      jest.spyOn(mockRange, 'setEnd');
-
-      const range = {index: startIndex, length: endIndex - startIndex};
-
-      cursors.moveCursor(cursor.id, range);
-
-      expect(mockRange.setStart).toHaveBeenCalledWith(startLeaf[0].domNode, startLeaf[1]);
-      expect(mockRange.setEnd).toHaveBeenCalledWith(line1Leaf[0].domNode, line1Leaf[1]);
-
-      expect(mockRange.setStart).toHaveBeenCalledWith(line2Leaf[0].domNode, line2Leaf[1]);
-      expect(mockRange.setEnd).toHaveBeenCalledWith(line1Leaf[0].domNode, line1Leaf[1]);
-    });
-
-    it('sets the range on either side of an image', () => {
-      const startIndex = 0;
-      const endIndex = 1;
+    it('sets the range on either side of an embed element', () => {
       const leaf = createLeaf('img');
       jest.spyOn(quill, 'getLeaf').mockImplementation(() => leaf);
-      jest.spyOn(quill, 'getLines').mockReturnValue([{
-        children: [],
-      }]);
       jest.spyOn(mockRange, 'setStartBefore');
       jest.spyOn(mockRange, 'setEndAfter');
 
-      const range = {index: startIndex, length: endIndex - startIndex};
-
-      cursors.moveCursor(cursor.id, range);
+      cursors.moveCursor(cursor.id, {index: 0, length: 1});
 
       expect(mockRange.setStartBefore).toHaveBeenCalledWith(leaf[0].domNode);
       expect(mockRange.setEndAfter).toHaveBeenCalledWith(leaf[0].domNode);
+    });
+
+    it('clears the highlight for a collapsed cursor', () => {
+      jest.spyOn(quill, 'getLeaf').mockReturnValue(createLeaf());
+      jest.spyOn(cursor, 'setSelectionRange');
+
+      cursors.moveCursor(cursor.id, {index: 0, length: 0});
+
+      expect(cursor.setSelectionRange).toHaveBeenCalledWith(null);
+    });
+
+    it('clears the highlight when the built range is collapsed', () => {
+      jest.spyOn(quill, 'getLeaf').mockReturnValue(createLeaf());
+      jest.spyOn(cursor, 'setSelectionRange');
+      mockRange.collapsed = true;
+
+      cursors.moveCursor(cursor.id, {index: 0, length: 1});
+
+      expect(cursor.setSelectionRange).toHaveBeenCalledWith(null);
     });
 
     describe('RTL positioning', () => {
@@ -553,7 +534,6 @@ describe('QuillCursors', () => {
         parentElement.appendChild(textNode);
 
         jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: textNode}, 0]);
-        jest.spyOn(quill, 'getLines').mockReturnValue([]);
         jest.spyOn(quill, 'getBounds').mockReturnValue({
           top: 10, left: 100, width: 0, height: 20,
         });
@@ -566,10 +546,6 @@ describe('QuillCursors', () => {
           getBoundingClientRect: () => ({
             left: 250, right: 260, width: 10, top: 10, height: 20, bottom: 30,
           }),
-          getClientRects: (): any[] => [],
-          cloneRange: () => charRange,
-          selectNode: () => {},
-          setStartBefore: () => {}, setEndAfter: () => {},
         };
         document.createRange = () => charRange as any;
 
@@ -589,7 +565,6 @@ describe('QuillCursors', () => {
         parentElement.appendChild(textNode);
 
         jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: textNode}, 4]);
-        jest.spyOn(quill, 'getLines').mockReturnValue([]);
         jest.spyOn(quill, 'getBounds').mockReturnValue({
           top: 10, left: 120, width: 0, height: 20,
         });
@@ -602,10 +577,6 @@ describe('QuillCursors', () => {
           getBoundingClientRect: () => ({
             left: 150, right: 160, width: 10, top: 10, height: 20, bottom: 30,
           }),
-          getClientRects: (): any[] => [],
-          cloneRange: () => charRange,
-          selectNode: () => {},
-          setStartBefore: () => {}, setEndAfter: () => {},
         };
         document.createRange = () => charRange as any;
 
@@ -625,7 +596,6 @@ describe('QuillCursors', () => {
         parentElement.appendChild(textNode);
 
         jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: textNode}, 0]);
-        jest.spyOn(quill, 'getLines').mockReturnValue([]);
         jest.spyOn(quill, 'getBounds').mockReturnValue({
           top: 10, left: 100, width: 0, height: 20,
         });
@@ -641,7 +611,6 @@ describe('QuillCursors', () => {
 
       it('defaults to LTR when leaf has no parent element', () => {
         jest.spyOn(quill, 'getLeaf').mockReturnValue(createLeaf());
-        jest.spyOn(quill, 'getLines').mockReturnValue([]);
         jest.spyOn(quill, 'getBounds').mockReturnValue({
           top: 10, left: 100, width: 0, height: 20,
         });
@@ -662,7 +631,6 @@ describe('QuillCursors', () => {
         parentElement.appendChild(textNode);
 
         jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: textNode}, 0]);
-        jest.spyOn(quill, 'getLines').mockReturnValue([]);
         jest.spyOn(quill, 'getBounds').mockReturnValue({
           top: 10, left: 100, width: 0, height: 20,
         });
@@ -675,10 +643,6 @@ describe('QuillCursors', () => {
           getBoundingClientRect: () => ({
             left: 250, right: 260, width: 10, top: 10, height: 20, bottom: 30,
           }),
-          getClientRects: (): any[] => [],
-          cloneRange: () => charRange,
-          selectNode: () => {},
-          setStartBefore: () => {}, setEndAfter: () => {},
         };
         document.createRange = () => charRange as any;
 
@@ -698,7 +662,6 @@ describe('QuillCursors', () => {
         parentElement.appendChild(img);
 
         jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: img}, 0]);
-        jest.spyOn(quill, 'getLines').mockReturnValue([]);
         jest.spyOn(quill, 'getBounds').mockReturnValue({
           top: 10, left: 100, width: 0, height: 20,
         });
@@ -729,7 +692,6 @@ describe('QuillCursors', () => {
         });
 
         jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: textNode}, 0]);
-        jest.spyOn(quill, 'getLines').mockReturnValue([]);
         jest.spyOn(quill, 'getBounds').mockReturnValue({
           top: 10, left: 100, width: 0, height: 20,
         });
@@ -742,10 +704,6 @@ describe('QuillCursors', () => {
           getBoundingClientRect: () => ({
             left: 250, right: 260, width: 10, top: 10, height: 20, bottom: 30,
           }),
-          getClientRects: (): any[] => [],
-          cloneRange: () => charRange,
-          selectNode: () => {},
-          setStartBefore: () => {}, setEndAfter: () => {},
         };
         document.createRange = () => charRange as any;
 
@@ -767,7 +725,6 @@ describe('QuillCursors', () => {
         parentElement.appendChild(textNode);
 
         jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: textNode}, 0]);
-        jest.spyOn(quill, 'getLines').mockReturnValue([]);
         jest.spyOn(quill, 'getBounds').mockReturnValue({
           top: 10, left: 100, width: 0, height: 20,
         });
@@ -788,7 +745,6 @@ describe('QuillCursors', () => {
         parentElement.appendChild(textNode);
 
         jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: textNode}, 0]);
-        jest.spyOn(quill, 'getLines').mockReturnValue([]);
         jest.spyOn(quill, 'getBounds').mockReturnValue({
           top: 10, left: 100, width: 0, height: 20,
         });
@@ -801,10 +757,6 @@ describe('QuillCursors', () => {
           getBoundingClientRect: () => ({
             left: 250, right: 260, width: 10, top: 10, height: 20, bottom: 30,
           }),
-          getClientRects: (): any[] => [],
-          cloneRange: () => charRange,
-          selectNode: () => {},
-          setStartBefore: () => {}, setEndAfter: () => {},
         };
         document.createRange = () => charRange as any;
 
@@ -1122,9 +1074,9 @@ describe('QuillCursors', () => {
       it('does not fire scroll handler when quill.constructor.find returns null', () => {
         quill.constructor.find.mockReturnValue(null);
         const localCursors = new QuillCursors(quill);
-        jest.spyOn(localCursors, 'update');
+        jest.spyOn(localCursors as any, '_updateCaretPositions');
         editor.dispatchEvent(new Event('scroll'));
-        expect(localCursors.update).not.toHaveBeenCalled();
+        expect((localCursors as any)._updateCaretPositions).not.toHaveBeenCalled();
       });
 
       it('calls destroy and removes the DOM listener when quill.constructor.find returns null on scroll', () => {

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -46,6 +46,7 @@ describe('QuillCursors', () => {
       getLeaf: (): any => {},
       getLength: (): number => 0,
       getSelection: (): void => {},
+      getLines: (): any[] => [],
       on: (): void => {},
       off: (): void => {},
     };
@@ -73,7 +74,7 @@ describe('QuillCursors', () => {
       expect(quill.addContainer).toHaveBeenCalledTimes(1);
     });
 
-    it('repositions only carets on scroll', () => {
+    it('repositions carets and embed overlays on scroll, without rebuilding highlights', () => {
       const editor = quill.root;
       jest.spyOn(editor, 'addEventListener');
       const cursors = new QuillCursors(quill);
@@ -84,11 +85,13 @@ describe('QuillCursors', () => {
       jest.spyOn(quill, 'getLeaf').mockReturnValue([{domNode: document.createTextNode('foo')}, 0]);
       jest.spyOn(quill, 'getBounds').mockReturnValue({top: 0, left: 0, width: 0, height: 0});
       jest.spyOn(cursor, 'updateCaret');
+      jest.spyOn(cursor, 'updateEmbedSelections');
       jest.spyOn(cursor, 'setSelectionRange');
 
       editor.dispatchEvent(new Event('scroll'));
 
       expect(cursor.updateCaret).toHaveBeenCalled();
+      expect(cursor.updateEmbedSelections).toHaveBeenCalled();
       expect(cursor.setSelectionRange).not.toHaveBeenCalled();
     });
 
@@ -524,6 +527,31 @@ describe('QuillCursors', () => {
       cursors.moveCursor(cursor.id, {index: 0, length: 1});
 
       expect(cursor.setSelectionRange).toHaveBeenCalledWith(null);
+    });
+
+    it('draws overlay blocks over block embeds in the selection', () => {
+      jest.spyOn(quill, 'getLeaf').mockReturnValue(createLeaf());
+      const embedRectangle = {top: 10, left: 20, width: 100, height: 50};
+      const embedLine = {domNode: {getBoundingClientRect: (): any => embedRectangle}};
+      const textLine = {children: {}, domNode: {}};
+      jest.spyOn(quill, 'getLines').mockReturnValue([textLine, embedLine]);
+      jest.spyOn(cursor, 'updateEmbedSelections');
+
+      cursors.moveCursor(cursor.id, {index: 0, length: 5});
+
+      expect(quill.getLines).toHaveBeenCalledWith(cursor.range);
+      expect(cursor.updateEmbedSelections).toHaveBeenCalledWith([embedRectangle], expect.anything());
+    });
+
+    it('passes no embed rectangles for a collapsed cursor', () => {
+      jest.spyOn(quill, 'getLeaf').mockReturnValue(createLeaf());
+      jest.spyOn(quill, 'getLines');
+      jest.spyOn(cursor, 'updateEmbedSelections');
+
+      cursors.moveCursor(cursor.id, {index: 0, length: 0});
+
+      expect(cursor.updateEmbedSelections).toHaveBeenCalledWith([], expect.anything());
+      expect(quill.getLines).not.toHaveBeenCalled();
     });
 
     describe('RTL positioning', () => {
@@ -1074,9 +1102,9 @@ describe('QuillCursors', () => {
       it('does not fire scroll handler when quill.constructor.find returns null', () => {
         quill.constructor.find.mockReturnValue(null);
         const localCursors = new QuillCursors(quill);
-        jest.spyOn(localCursors as any, '_updateCaretPositions');
+        jest.spyOn(localCursors as any, '_repositionCursors');
         editor.dispatchEvent(new Event('scroll'));
-        expect((localCursors as any)._updateCaretPositions).not.toHaveBeenCalled();
+        expect((localCursors as any)._repositionCursors).not.toHaveBeenCalled();
       });
 
       it('calls destroy and removes the DOM listener when quill.constructor.find returns null on scroll', () => {

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -46,7 +46,9 @@ describe('QuillCursors', () => {
       getLeaf: (): any => {},
       getLength: (): number => 0,
       getSelection: (): void => {},
-      getLines: (): any[] => [],
+      scroll: {
+        descendants: (): any[] => [],
+      },
       on: (): void => {},
       off: (): void => {},
     };
@@ -529,29 +531,41 @@ describe('QuillCursors', () => {
       expect(cursor.setSelectionRange).toHaveBeenCalledWith(null);
     });
 
-    it('draws overlay blocks over block embeds in the selection', () => {
+    it('draws overlay rectangles over embeds in the selection', () => {
       jest.spyOn(quill, 'getLeaf').mockReturnValue(createLeaf());
       const embedRectangle = {top: 10, left: 20, width: 100, height: 50};
-      const embedLine = {domNode: {getBoundingClientRect: (): any => embedRectangle}};
-      const textLine = {children: {}, domNode: {}};
-      jest.spyOn(quill, 'getLines').mockReturnValue([textLine, embedLine]);
+      const embedBlot = {domNode: {getBoundingClientRect: (): any => embedRectangle}};
+      jest.spyOn(quill.scroll, 'descendants').mockReturnValue([embedBlot]);
       jest.spyOn(cursor, 'updateEmbedSelections');
+
+      cursors.moveCursor(cursor.id, {index: 3, length: 5});
+
+      expect(quill.scroll.descendants).toHaveBeenCalledWith(expect.any(Function), 3, 5);
+      expect(cursor.updateEmbedSelections).toHaveBeenCalledWith([embedRectangle], expect.anything());
+    });
+
+    it('identifies embed leaves structurally, covering custom blots', () => {
+      jest.spyOn(quill, 'getLeaf').mockReturnValue(createLeaf());
+      jest.spyOn(quill.scroll, 'descendants').mockReturnValue([]);
 
       cursors.moveCursor(cursor.id, {index: 0, length: 5});
 
-      expect(quill.getLines).toHaveBeenCalledWith(cursor.range);
-      expect(cursor.updateEmbedSelections).toHaveBeenCalledWith([embedRectangle], expect.anything());
+      const criteria = (quill.scroll.descendants as jest.Mock).mock.calls[0][0];
+      expect(criteria({children: {}, domNode: document.createElement('p')})).toBe(false);
+      expect(criteria({domNode: document.createTextNode('text')})).toBe(false);
+      expect(criteria({domNode: document.createElement('img')})).toBe(true);
+      expect(criteria({domNode: document.createElement('my-custom-embed')})).toBe(true);
     });
 
     it('passes no embed rectangles for a collapsed cursor', () => {
       jest.spyOn(quill, 'getLeaf').mockReturnValue(createLeaf());
-      jest.spyOn(quill, 'getLines');
+      jest.spyOn(quill.scroll, 'descendants');
       jest.spyOn(cursor, 'updateEmbedSelections');
 
       cursors.moveCursor(cursor.id, {index: 0, length: 0});
 
       expect(cursor.updateEmbedSelections).toHaveBeenCalledWith([], expect.anything());
-      expect(quill.getLines).not.toHaveBeenCalled();
+      expect(quill.scroll.descendants).not.toHaveBeenCalled();
     });
 
     describe('RTL positioning', () => {

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -119,12 +119,12 @@ export default class QuillCursors {
   };
 
   // Highlights are repainted natively by the browser on scroll/resize; only
-  // the absolutely-positioned elements (carets, flags and block-embed
-  // overlays) go stale. Skipping the range rebuild also avoids needless
-  // highlight repaints. Trade-off: if a cursor was hidden by a SILENT content
-  // change (no text-change event), this path re-shows its caret but its
-  // selection stays unpainted until the next full update — preferable to v4,
-  // which re-revealed stale, mispositioned rects.
+  // the absolutely-positioned elements (carets, flags and embed overlays) go
+  // stale. Skipping the range rebuild also avoids needless highlight
+  // repaints. Trade-off: if a cursor was hidden by a SILENT content change
+  // (no text-change event), this path re-shows its caret but its selection
+  // stays unpainted until the next full update — preferable to v4, which
+  // re-revealed stale, mispositioned rects.
   private _repositionCursors(): void {
     this.cursors().forEach((cursor: Cursor) => this._updateCursor(cursor, true));
   }
@@ -377,18 +377,23 @@ export default class QuillCursors {
     return range.collapsed ? null : range;
   }
 
-  // Block embeds (lines without children, e.g. video) are not painted by the
-  // Highlight API, so they get tinted overlay rectangles instead. Inline
-  // embeds are skipped, matching native selection painting.
+  // Embeds are not painted by the Highlight API, so every embed leaf in the
+  // selection — inline (e.g. images) or block (e.g. videos) — gets a tinted
+  // overlay rectangle, the way native selection paints replaced elements.
+  // The criteria is structural rather than a list of blot types: any leaf
+  // blot that isn't a text node is an embed, so custom blots are covered too.
   private _embedRectangles(cursor: Cursor): ClientRect[] {
     if (!cursor.range.length) {
       return [];
     }
 
-    const lines = this.quill.getLines(cursor.range);
-    return lines
-      .filter((line: any) => !line.children)
-      .map((line: any) => line.domNode.getBoundingClientRect());
+    const embeds = this.quill.scroll.descendants(
+      (blot: any) => !blot.children && !(blot.domNode instanceof Text),
+      cursor.range.index,
+      cursor.range.length,
+    );
+
+    return embeds.map((blot: any) => blot.domNode.getBoundingClientRect());
   }
 
   private _transformCursors(delta: Delta): void {

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -381,7 +381,7 @@ export default class QuillCursors {
     }
 
     const embeds = this.quill.scroll.descendants(
-      (blot: any) => !blot.children && !(blot.domNode instanceof Text),
+      (blot: any) => !blot.children && blot.domNode.nodeType !== Node.TEXT_NODE,
       cursor.range.index,
       cursor.range.length,
     );

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -1,9 +1,8 @@
 import IQuillCursorsOptions from './i-quill-cursors-options';
 import Cursor from './cursor';
 import IQuillRange from './i-range';
-import * as RangeFix from 'rangefix';
+import CursorHighlight from './cursor-highlight';
 import template from './template';
-import ResizeObserver from 'resize-observer-polyfill';
 import Delta = require('quill-delta');
 
 export default class QuillCursors {
@@ -31,6 +30,7 @@ export default class QuillCursors {
   private _domListeners: Array<{target: HTMLElement; event: string; wrapped: EventListener}> = [];
 
   public constructor(quill: any, options: IQuillCursorsOptions = {}) {
+    CursorHighlight.warnIfUnsupported();
     this.quill = quill;
     this.options = this._setDefaults(options);
     this._container = this.quill.addContainer(this.options.containerClass);
@@ -115,8 +115,18 @@ export default class QuillCursors {
   }
 
   private readonly _onScroll = (): void => {
-    this.update();
+    this._updateCaretPositions();
   };
+
+  // Highlights are repainted natively by the browser on scroll/resize; only
+  // the absolutely-positioned caret and flag go stale. Skipping the range
+  // rebuild also avoids needless highlight repaints. Trade-off: if a cursor
+  // was hidden by a SILENT content change (no text-change event), this path
+  // re-shows its caret but its selection stays unpainted until the next full
+  // update — preferable to v4, which re-revealed stale, mispositioned rects.
+  private _updateCaretPositions(): void {
+    this.cursors().forEach((cursor: Cursor) => this._updateCursor(cursor, true));
+  }
 
   private readonly _handleCursorTouch = (e: MouseEvent): void => {
     this.cursors().forEach((cursor) => {
@@ -195,14 +205,14 @@ export default class QuillCursors {
         this._isObserving = false;
         return;
       }
-      this.update();
+      this._updateCaretPositions();
     });
 
     this._resizeObserver.observe(editor);
     this._isObserving = true;
   }
 
-  private _updateCursor(cursor: Cursor): void {
+  private _updateCursor(cursor: Cursor, caretOnly = false): void {
     this._registerResizeObserver();
 
     if (!cursor.range) {
@@ -230,11 +240,11 @@ export default class QuillCursors {
     }
     cursor.updateCaret(endBounds, containerRectangle);
 
-    const ranges = this._lineRanges(cursor, startLeaf, endLeaf);
-    const selectionRectangles = ranges
-      .reduce((rectangles, range) => rectangles.concat(Array.from(RangeFix.getClientRects(range))), []);
+    if (caretOnly) {
+      return;
+    }
 
-    cursor.updateSelection(selectionRectangles, containerRectangle);
+    cursor.setSelectionRange(this._selectionRange(cursor, startLeaf, endLeaf));
   }
 
   // Quill's getBounds() returns width:0 for cursor positions, losing the
@@ -338,45 +348,31 @@ export default class QuillCursors {
     return options;
   }
 
-  // Rather than just use the start leaf and end leaf directly to build a single range,
-  // we instead find all the lines in that single range and create a sub-range for each
-  // of these lines. This avoids the browser creating a range around an entire paragraph
-  // element, and instead forces the browser to draw rectangles around the paragraph's
-  // constituent text nodes, which is more consistent with the existing browser selection
-  // behaviour.
-  private _lineRanges(cursor: Cursor, startLeaf: any[], endLeaf: any[]): Range[] {
-    const lines = this.quill.getLines(cursor.range);
-    return lines.reduce((ranges: Range[], line: any, index: number) => {
-      if (!line.children) {
-        const singleElementRange = document.createRange();
-        singleElementRange.selectNode(line.domNode);
-        return ranges.concat(singleElementRange);
-      }
+  // Builds a single DOM Range spanning the cursor's selection. The CSS Custom
+  // Highlight API paints a multi-line range exactly like a native selection,
+  // so no per-line splitting or rectangle computation is needed.
+  private _selectionRange(cursor: Cursor, startLeaf: any[], endLeaf: any[]): Range | null {
+    if (!cursor.range.length) {
+      return null;
+    }
 
-      const [rangeStart, startOffset] = index === 0 ?
-        startLeaf :
-        line.path(0).pop();
+    const range = document.createRange();
+    const [startBlot, startOffset] = startLeaf;
+    const [endBlot, endOffset] = endLeaf;
 
-      const [rangeEnd, endOffset] = index === lines.length - 1 ?
-        endLeaf :
-        line.path(line.length() - 1).pop();
+    if (startBlot.domNode.nodeType === Node.TEXT_NODE) {
+      range.setStart(startBlot.domNode, startOffset);
+    } else {
+      range.setStartBefore(startBlot.domNode);
+    }
 
-      const range = document.createRange();
+    if (endBlot.domNode.nodeType === Node.TEXT_NODE) {
+      range.setEnd(endBlot.domNode, endOffset);
+    } else {
+      range.setEndAfter(endBlot.domNode);
+    }
 
-      if (rangeStart.domNode.nodeType === Node.TEXT_NODE) {
-        range.setStart(rangeStart.domNode, startOffset);
-      } else {
-        range.setStartBefore(rangeStart.domNode);
-      }
-
-      if (rangeEnd.domNode.nodeType === Node.TEXT_NODE) {
-        range.setEnd(rangeEnd.domNode, endOffset);
-      } else {
-        range.setEndAfter(rangeEnd.domNode);
-      }
-
-      return ranges.concat(range);
-    }, []);
+    return range.collapsed ? null : range;
   }
 
   private _transformCursors(delta: Delta): void {

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -119,12 +119,8 @@ export default class QuillCursors {
   };
 
   // Highlights are repainted natively by the browser on scroll/resize; only
-  // the absolutely-positioned elements (carets, flags and embed overlays) go
-  // stale. Skipping the range rebuild also avoids needless highlight
-  // repaints. Trade-off: if a cursor was hidden by a SILENT content change
-  // (no text-change event), this path re-shows its caret but its selection
-  // stays unpainted until the next full update — preferable to v4, which
-  // re-revealed stale, mispositioned rects.
+  // the absolutely-positioned carets, flags and embed overlays go stale, so
+  // skip the range rebuild and its needless highlight repaints.
   private _repositionCursors(): void {
     this.cursors().forEach((cursor: Cursor) => this._updateCursor(cursor, true));
   }
@@ -350,9 +346,8 @@ export default class QuillCursors {
     return options;
   }
 
-  // Builds a single DOM Range spanning the cursor's selection. The CSS Custom
-  // Highlight API paints a multi-line range exactly like a native selection,
-  // so no per-line splitting or rectangle computation is needed.
+  // The Highlight API paints a multi-line Range like a native selection, so a
+  // single Range per cursor is enough.
   private _selectionRange(cursor: Cursor, startLeaf: any[], endLeaf: any[]): Range | null {
     if (!cursor.range.length) {
       return null;
@@ -377,11 +372,9 @@ export default class QuillCursors {
     return range.collapsed ? null : range;
   }
 
-  // Embeds are not painted by the Highlight API, so every embed leaf in the
-  // selection — inline (e.g. images) or block (e.g. videos) — gets a tinted
-  // overlay rectangle, the way native selection paints replaced elements.
-  // The criteria is structural rather than a list of blot types: any leaf
-  // blot that isn't a text node is an embed, so custom blots are covered too.
+  // The Highlight API only paints text, so embed leaves in the selection get
+  // tinted overlay rectangles. Any childless blot with a non-text DOM node is
+  // an embed: inline (images) or block (videos), stock or custom.
   private _embedRectangles(cursor: Cursor): ClientRect[] {
     if (!cursor.range.length) {
       return [];

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -115,16 +115,17 @@ export default class QuillCursors {
   }
 
   private readonly _onScroll = (): void => {
-    this._updateCaretPositions();
+    this._repositionCursors();
   };
 
   // Highlights are repainted natively by the browser on scroll/resize; only
-  // the absolutely-positioned caret and flag go stale. Skipping the range
-  // rebuild also avoids needless highlight repaints. Trade-off: if a cursor
-  // was hidden by a SILENT content change (no text-change event), this path
-  // re-shows its caret but its selection stays unpainted until the next full
-  // update — preferable to v4, which re-revealed stale, mispositioned rects.
-  private _updateCaretPositions(): void {
+  // the absolutely-positioned elements (carets, flags and block-embed
+  // overlays) go stale. Skipping the range rebuild also avoids needless
+  // highlight repaints. Trade-off: if a cursor was hidden by a SILENT content
+  // change (no text-change event), this path re-shows its caret but its
+  // selection stays unpainted until the next full update — preferable to v4,
+  // which re-revealed stale, mispositioned rects.
+  private _repositionCursors(): void {
     this.cursors().forEach((cursor: Cursor) => this._updateCursor(cursor, true));
   }
 
@@ -205,14 +206,14 @@ export default class QuillCursors {
         this._isObserving = false;
         return;
       }
-      this._updateCaretPositions();
+      this._repositionCursors();
     });
 
     this._resizeObserver.observe(editor);
     this._isObserving = true;
   }
 
-  private _updateCursor(cursor: Cursor, caretOnly = false): void {
+  private _updateCursor(cursor: Cursor, positionsOnly = false): void {
     this._registerResizeObserver();
 
     if (!cursor.range) {
@@ -239,8 +240,9 @@ export default class QuillCursors {
       endBounds = this._adjustBoundsForRtl(endBounds, endLeaf);
     }
     cursor.updateCaret(endBounds, containerRectangle);
+    cursor.updateEmbedSelections(this._embedRectangles(cursor), containerRectangle);
 
-    if (caretOnly) {
+    if (positionsOnly) {
       return;
     }
 
@@ -373,6 +375,20 @@ export default class QuillCursors {
     }
 
     return range.collapsed ? null : range;
+  }
+
+  // Block embeds (lines without children, e.g. video) are not painted by the
+  // Highlight API, so they get tinted overlay rectangles instead. Inline
+  // embeds are skipped, matching native selection painting.
+  private _embedRectangles(cursor: Cursor): ClientRect[] {
+    if (!cursor.range.length) {
+      return [];
+    }
+
+    const lines = this.quill.getLines(cursor.range);
+    return lines
+      .filter((line: any) => !line.children)
+      .map((line: any) => line.domNode.getBoundingClientRect());
   }
 
   private _transformCursors(delta: Delta): void {

--- a/src/quill-cursors/template.ts
+++ b/src/quill-cursors/template.ts
@@ -1,7 +1,6 @@
 import Cursor from './cursor';
 
 const template = `
-  <span class="${ Cursor.SELECTION_CLASS }"></span>
   <span class="${ Cursor.CARET_CONTAINER_CLASS }">
     <span class="${ Cursor.CARET_CLASS }"></span>
   </span>

--- a/src/quill-cursors/template.ts
+++ b/src/quill-cursors/template.ts
@@ -1,6 +1,7 @@
 import Cursor from './cursor';
 
 const template = `
+  <span class="${ Cursor.SELECTION_CLASS }"></span>
   <span class="${ Cursor.CARET_CONTAINER_CLASS }">
     <span class="${ Cursor.CARET_CLASS }"></span>
   </span>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "exclude": [
     "./src/*.spec.ts",
     "./src/**/*.spec.ts",
+    "./src/jest.setup.ts",
   ],
   "compilerOptions": {
     "outDir": "./dist/",

--- a/typings/highlight.d.ts
+++ b/typings/highlight.d.ts
@@ -1,0 +1,31 @@
+// Type declarations for the CSS Custom Highlight API.
+// The built-in lib.dom types only ship with TypeScript 5.5+, so declare the
+// small surface we use here, mirroring the lib.dom shape so this file can
+// simply be deleted when TypeScript is upgraded.
+// https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API
+
+type HighlightType = 'highlight' | 'spelling-error' | 'grammar-error';
+
+interface Highlight extends Set<AbstractRange> {
+  priority: number;
+  type: HighlightType;
+}
+
+declare var Highlight: {
+  prototype: Highlight;
+  new(...initialRanges: AbstractRange[]): Highlight;
+};
+
+interface HighlightRegistry extends Map<string, Highlight> {
+}
+
+declare var HighlightRegistry: {
+  prototype: HighlightRegistry;
+  new(): HighlightRegistry;
+};
+
+declare namespace CSS {
+  // Deliberately typed as optional, unlike lib.dom: this API is feature-
+  // detected at runtime, and the type should force callers to check.
+  const highlights: HighlightRegistry | undefined;
+}

--- a/typings/rangefix.d.ts
+++ b/typings/rangefix.d.ts
@@ -1,1 +1,0 @@
-declare module 'rangefix';


### PR DESCRIPTION
## Summary

Implements #98: replace the manually computed selection rectangles with the native [CSS Custom Highlight API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API). This is a full rewrite of selection rendering and ships as a major version (**5.0.0**).

Previously each remote cursor's selection was drawn as absolutely-positioned `<span>` elements, with per-line `Range` splitting and `RangeFix.getClientRects()` recomputed on every update — including on every scroll frame. Now each cursor registers a `Highlight` in the global `CSS.highlights` registry and the browser paints it natively, like a real selection, repainting it on scroll, resize, and reflow with no work from us.

## How it works

- **`CursorHighlight`** (new) owns one registry entry per cursor (`ql-cursor-highlight-<n>`) plus a per-cursor [constructable stylesheet](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) adopted into the editor's `Document` or `ShadowRoot`: `::highlight(<name>) { background-color: color-mix(in srgb, <color> 30%, transparent); }`.
- **`QuillCursors`** builds a single DOM `Range` per cursor from the Quill start/end leaves and hands it to the highlight. The per-line splitting that only existed to make `getClientRects()` mimic a native selection is gone.
- **Scroll/resize** now only reposition the caret and flag DOM elements; the browser repaints the highlights itself, so the per-frame rectangle recompute is eliminated.
- Embeds are not painted by the Highlight API, so every embed leaf in the selection (inline like images, block like videos, custom blots included) gets a tinted overlay rectangle, reusing the v4 `.ql-cursor-selection-block` machinery. These reposition with the caret on scroll/resize.
- Support is gated once at construction: `Cursor` picks `CursorHighlight` or a `NoOpCursorHighlight`, so no per-call feature checks. Overlapping selections stack deterministically via `Highlight.priority` (creation order).
- The caret and name flag remain plain DOM elements (the Highlight API cannot render them).

## Breaking changes (5.0.0)

- **Browser support floor** for selection rendering: Chrome/Edge **111+**, Safari **17.2+**, Firefox **140+** (111 rather than 105 because of `color-mix()`). Older browsers degrade gracefully — carets and name flags still work, selections simply aren't drawn, and a single console warning is logged. Projects that need selection rendering on older browsers should stay on the 4.x line.
- The `<span class="ql-cursor-selections">` template element and `.ql-cursor-selection-block` spans are now only used for embed overlays; text selections no longer create DOM elements. Templates without the selections element are tolerated.
- `cursor.updateSelection(rects, container)` is replaced by `cursor.setSelectionRange(range: Range | null)` for text and `cursor.updateEmbedSelections(rects, container)` for embeds.
- Embeds within a remote selection are covered by a tinted overlay rectangle (the Highlight API itself only paints text). This includes small inline widgets that native selection skips — everything in the range is visibly selected.
- Dropped the `rangefix` and `resize-observer-polyfill` dependencies (native `ResizeObserver` is used), so the runtime bundle is smaller.

## New

- `cursor.highlightName` exposes the `CSS.highlights` registry name, so applications can layer extra styling via `::highlight(<name>)`.
- Cursor colors are validated with `CSS.supports()` before being written into a highlight rule (invalid values fall back to `transparent`). This preserves CSS-custom-property colors such as `var(--user-color)` while preventing a malformed color from escaping the declaration and injecting arbitrary CSS — something an inline `style` assignment guarded against implicitly but a stylesheet does not.
- Highlight styles use constructable stylesheets: CSP-safe in **both** bundles, and adopted into the editor's actual root so Shadow DOM works.

## Known differences

- In Safari, inter-line whitespace may not be tinted when a selection wraps across lines — a platform limitation of `::highlight()` painting, not specific to this library.

## Testing

- 138 unit tests, 100% coverage (branches / functions / lines / statements) maintained throughout.
- Manually verified in a browser with the two-editor example: cross-editor selection painting, `var(--…)` colors resolving through `color-mix()`, multiple editor instances sharing the global registry without name collisions, caret tracking while scrolling a fixed-height editor, multi-line and mixed-format selections, RTL caret positioning, the carets-only + single-warning degradation path when the API is unavailable, and embed overlays (the example toolbar now has image and video controls for this).

Closes #98

