### PR TITLE
Emit the selection when a drag ends outside the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.0.1
+- Fix remote selections going stale when a selection drag ends outside the browser window ([#104](https://github.com/reedsy/quill-cursors/issues/104))
+
 # 5.0.0
 
 ### ⚠ BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-cursors",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A multi cursor module for Quill.",
   "keywords": [
     "quill",

--- a/src/quill-cursors/quill-cursors.spec.ts
+++ b/src/quill-cursors/quill-cursors.spec.ts
@@ -293,6 +293,58 @@ describe('QuillCursors', () => {
     });
   });
 
+  describe('reconciling selections missed by Quill', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('registers a document selectionchange listener', () => {
+      jest.spyOn(document, 'addEventListener');
+      new QuillCursors(quill);
+      expect(document.addEventListener)
+        .toHaveBeenCalledWith('selectionchange', expect.anything(), undefined);
+    });
+
+    it('nudges Quill to reconcile once the selection has settled', () => {
+      jest.useFakeTimers();
+      new QuillCursors(quill);
+      jest.spyOn(quill, 'getSelection');
+
+      document.dispatchEvent(new Event('selectionchange'));
+      expect(quill.getSelection).not.toHaveBeenCalled();
+
+      jest.runAllTimers();
+      expect(quill.getSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it('debounces the nudge while the selection keeps changing', () => {
+      jest.useFakeTimers();
+      new QuillCursors(quill);
+      jest.spyOn(quill, 'getSelection');
+
+      document.dispatchEvent(new Event('selectionchange'));
+      jest.advanceTimersByTime(200);
+      document.dispatchEvent(new Event('selectionchange'));
+      jest.advanceTimersByTime(200);
+      expect(quill.getSelection).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(100);
+      expect(quill.getSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not nudge while an IME composition is in progress', () => {
+      jest.useFakeTimers();
+      quill.selection = {composing: true};
+      new QuillCursors(quill);
+      jest.spyOn(quill, 'getSelection');
+
+      document.dispatchEvent(new Event('selectionchange'));
+      jest.runAllTimers();
+
+      expect(quill.getSelection).not.toHaveBeenCalled();
+    });
+  });
+
   describe('creating a cursor', () => {
     it('creates a cursor', () => {
       const cursors = new QuillCursors(quill);
@@ -904,6 +956,22 @@ describe('QuillCursors', () => {
       editor.dispatchEvent(new TouchEvent('touchstart'));
       jest.runAllTimers();
       expect(cursor.toggleNearCursor).not.toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+
+    it('removes the document selectionchange listener', () => {
+      jest.spyOn(document, 'removeEventListener');
+      cursors.destroy();
+      expect(document.removeEventListener).toHaveBeenCalledWith('selectionchange', expect.anything());
+    });
+
+    it('does not nudge Quill when destroyed before the selection settle timer fires', () => {
+      jest.useFakeTimers();
+      jest.spyOn(quill, 'getSelection');
+      document.dispatchEvent(new Event('selectionchange'));
+      cursors.destroy();
+      jest.runAllTimers();
+      expect(quill.getSelection).not.toHaveBeenCalled();
       jest.useRealTimers();
     });
 

--- a/src/quill-cursors/quill-cursors.ts
+++ b/src/quill-cursors/quill-cursors.ts
@@ -14,6 +14,8 @@ export default class QuillCursors {
     hideSpeedMs: 400,
   };
 
+  private static readonly SELECTION_SETTLE_MS = 300;
+
   public readonly quill: any;
   public readonly options: IQuillCursorsOptions;
 
@@ -27,7 +29,8 @@ export default class QuillCursors {
   private _resizeObserver: ResizeObserver | null = null;
   private _touchTimerIds: ReturnType<typeof setTimeout>[] = [];
   private _quillListeners: Array<{ event: string; wrapped: (...args: any[]) => void }> = [];
-  private _domListeners: Array<{target: HTMLElement; event: string; wrapped: EventListener}> = [];
+  private _domListeners: Array<{target: HTMLElement | Document; event: string; wrapped: EventListener}> = [];
+  private _selectionSettleTimerId: ReturnType<typeof setTimeout> | null = null;
 
   public constructor(quill: any, options: IQuillCursorsOptions = {}) {
     CursorHighlight.warnIfUnsupported();
@@ -104,6 +107,10 @@ export default class QuillCursors {
     this.clearCursors();
     this._touchTimerIds.forEach((id) => clearTimeout(id));
     this._touchTimerIds = [];
+    if (this._selectionSettleTimerId != null) {
+      clearTimeout(this._selectionSettleTimerId);
+      this._selectionSettleTimerId = null;
+    }
     this._quillListeners.forEach(({event, wrapped}) => this.quill.off(event, wrapped));
     this._quillListeners = [];
     this._domListeners.forEach(({target, event, wrapped}) => target.removeEventListener(event, wrapped));
@@ -150,7 +157,7 @@ export default class QuillCursors {
   }
 
   private _addDomListener(
-    target: HTMLElement,
+    target: HTMLElement | Document,
     event: string,
     handler: EventListener,
     options?: AddEventListenerOptions,
@@ -187,6 +194,28 @@ export default class QuillCursors {
   private _registerDomListeners(): void {
     this._addDomListener(this._editor, 'scroll', this._onScroll, {passive: true});
     this._addDomListener(this._editor, 'touchstart', this._handleCursorTouch as EventListener, {passive: true});
+    this._addDomListener(document, 'selectionchange', this._onDocumentSelectionChange);
+  }
+
+  // Quill only emits a mouse selection on the mouseup ending the drag, and
+  // that mouseup never arrives if the button is released outside the window.
+  // Once the selection settles, getSelection() makes Quill reconcile against
+  // its last known range and emit the missed 'user' selection-change itself.
+  private readonly _onDocumentSelectionChange = (): void => {
+    if (this._selectionSettleTimerId != null) {
+      clearTimeout(this._selectionSettleTimerId);
+    }
+    this._selectionSettleTimerId = setTimeout(() => {
+      this._selectionSettleTimerId = null;
+      this._nudgeSelectionEmission();
+    }, QuillCursors.SELECTION_SETTLE_MS);
+  };
+
+  private _nudgeSelectionEmission(): void {
+    if (this._destroyed || this.quill.selection?.composing) {
+      return;
+    }
+    this.quill.getSelection();
   }
 
   private _registerResizeObserver(): void {


### PR DESCRIPTION
Fixes #104

Quill only emits a mouse selection on the `mouseup` that ends the drag, and that `mouseup` never reaches the page when the button is released outside the window — so the final `selection-change` is never emitted, and Quill's stuck drag-tracking flag suppresses further selection updates until the next click.

This adds a document `selectionchange` listener that, once the selection has settled for 300ms, calls `quill.getSelection()`. That makes Quill reconcile the native selection against its last known range and emit the missed `'user'` selection-change itself. In flows Quill already handles, the ranges match by then and the nudge is a no-op; during outside-the-window autoscroll the events keep resetting the debounce, so the nudge lands right after the drag stops. Skipped mid-IME-composition, cleaned up on `destroy()`.

Verified in the dev setup by synthesizing the drag via CDP with the `mouseup` withheld: before, no event fires and the remote view stays stale; after, the remote highlight updates ~300ms after release.


https://github.com/user-attachments/assets/d577d6e3-524a-4ac0-ab17-f1849ef1f377

