### PR TITLE
🙈 Ignore Claude Code worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage/
 # Consumers will override this anyway, so don't bother committing
 package-lock.json
 yarn.lock
+
+.claude/worktrees/


### PR DESCRIPTION
Claude Code creates its git worktrees under `.claude/worktrees/`, so a checkout that has run one shows the whole directory as untracked in `git status`.

This change ignores `.claude/worktrees/` specifically, rather than all of `.claude/`, so that any project-level config we do want to share stays trackable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

