### PR TITLE
📝 Point the CI badge at the workflow that exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![NPM Version](https://img.shields.io/npm/v/quill-cursors.svg)](https://npmjs.org/package/quill-cursors)
-[![Test](https://github.com/reedsy/quill-cursors/actions/workflows/test.yml/badge.svg)](https://github.com/reedsy/quill-cursors/actions/workflows/test.yml)
+[![CI](https://github.com/reedsy/quill-cursors/actions/workflows/ci.yml/badge.svg)](https://github.com/reedsy/quill-cursors/actions/workflows/ci.yml)
 
 # quill-cursors
 


### PR DESCRIPTION
At the moment, the README's status badge points at a `test.yml` workflow, which doesn't exist in this repo.

GitHub serves its "no status" placeholder for an unknown workflow file, and the badge links through to a 404, so we advertise a broken build status on the repo front page and on npm.

Our only workflow is `ci.yml`, so this change points both the image and the link at it, and renames the badge from `Test` to `CI` to match the workflow's own name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

